### PR TITLE
Dashboard Import Fixes

### DIFF
--- a/lib/components/Dashboard.vue
+++ b/lib/components/Dashboard.vue
@@ -196,6 +196,7 @@ function handleToggleEditMode() {
       <ChartEditor
         :connectionName="getItemData(editingItem.i, dashboard.id).connectionName || ''"
         :imports="getItemData(editingItem.i, dashboard.id).imports || []"
+        :rootContent="getItemData(editingItem.i, dashboard.id).rootContent || []"
         :content="getItemData(editingItem.i, dashboard.id).content"
         :showing="showQueryEditor"
         @save="dashboardBase?.saveContent"

--- a/lib/components/DashboardCreatorInline.vue
+++ b/lib/components/DashboardCreatorInline.vue
@@ -37,7 +37,7 @@
         <option
           v-for="importItem in availableImports"
           :key="importItem.name"
-          :value="importItem.name"
+          :value="importItem.id"
         >
           {{ importItem.name }}
         </option>
@@ -81,7 +81,7 @@ import type { ConnectionStoreType } from '../stores/connectionStore'
 import type { LLMConnectionStoreType } from '../stores/llmStore'
 import QueryExecutionService from '../stores/queryExecutionService'
 import { type EditorStoreType } from '../stores/editorStore'
-import { type Import } from '../stores/resolver'
+import { type DashboardImport } from '../dashboards/base'
 
 export default {
   name: 'DashboardCreatorInline',
@@ -128,22 +128,22 @@ export default {
       return Object.values(connectionStore.connections).filter((conn) => conn.model)
     })
 
-    const availableImports: Ref<Import[]> = computed(() => {
+    const availableImports: Ref<DashboardImport[]> = computed(() => {
       const imports = Object.values(editorStore.editors).filter(
         (editor) => editor.connection === selectedConnection.value,
       )
 
       return imports.map((importItem) => ({
+        id: importItem.id,
         name: importItem.name,
         alias: importItem.name,
       }))
     })
 
     // Set default import when imports are available
-    // Watch for changes in availableImports and update selectedImport accordingly
     computed(() => {
       if (availableImports.value.length > 0 && !selectedImport.value) {
-        selectedImport.value = availableImports.value[0].name
+        selectedImport.value = availableImports.value[0].id
       } else if (availableImports.value.length === 0) {
         // Reset selectedImport if no imports are available
         selectedImport.value = ''
@@ -163,16 +163,11 @@ export default {
         const dashboard = dashboardStore.newDashboard(dashboardName.value, selectedConnection.value)
 
         // Use the selected import instead of hardcoded 'lineitem'
-        const importToUse =
-          selectedImport.value ||
-          (availableImports.value.length > 0 ? availableImports.value[0].name : '')
-
-        dashboardStore.updateDashboardImports(dashboard.id, [
-          {
-            name: importToUse,
-            alias: '',
-          },
-        ])
+        const importToUse = availableImports.value.find((imp) => imp.id === selectedImport.value)
+        if (!importToUse) {
+          throw new Error('Selected import not found')
+        }
+        dashboardStore.updateDashboardImports(dashboard.id, [importToUse])
 
         // Reset form
         dashboardName.value = ''

--- a/lib/components/DashboardHeader.vue
+++ b/lib/components/DashboardHeader.vue
@@ -4,7 +4,8 @@ import { useConnectionStore, useEditorStore } from '../stores'
 import DashboardImportSelector from './DashboardImportSelector.vue'
 import DashboardSharePopup from './DashboardSharePopup.vue'
 import FilterInputComponent from './DashboardHeaderFilterInput.vue'
-import { type Import, type CompletionItem } from '../stores/resolver'
+import { type CompletionItem } from '../stores/resolver'
+import { type DashboardImport } from '../dashboards/base'
 
 const props = defineProps({
   dashboard: {
@@ -65,14 +66,15 @@ function handleFilterApply(newValue: string) {
   emit('filter-change', newValue)
 }
 
-const availableImports: Ref<Import[]> = computed(() => {
+const availableImports: Ref<DashboardImport[]> = computed(() => {
   const imports = Object.values(editorStore.editors).filter(
     (editor) => editor.connection === props.selectedConnection,
   )
 
   return imports.map((importItem) => ({
+    id: importItem.id,
     name: importItem.name,
-    alias: importItem.name,
+    alias: '',
   }))
 })
 
@@ -80,7 +82,7 @@ const availableImports: Ref<Import[]> = computed(() => {
 const activeImports = computed(() => props.dashboard?.imports || [])
 
 // Handle imports change
-function handleImportsChange(newImports: Import[]) {
+function handleImportsChange(newImports: DashboardImport[]) {
   emit('import-change', newImports)
 }
 

--- a/lib/components/DashboardImportSelector.vue
+++ b/lib/components/DashboardImportSelector.vue
@@ -1,17 +1,17 @@
 <!-- ImportSelector.vue -->
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
-import { type Import } from '../stores/resolver'
+import { type DashboardImport } from '../dashboards/base'
 
 interface ImportSelectorProps {
-  availableImports: Import[]
-  activeImports: Import[]
+  availableImports: DashboardImport[]
+  activeImports: DashboardImport[]
 }
 
 const props = defineProps<ImportSelectorProps>()
 
 const emit = defineEmits<{
-  'update:imports': [imports: Import[]]
+  'update:imports': [imports: DashboardImport[]]
 }>()
 
 // Show/hide dropdown
@@ -28,20 +28,20 @@ function closeDropdown(): void {
 }
 
 // Check if import is active
-function isImportActive(importName: string): boolean {
-  return props.activeImports.some((imp) => imp.name === importName)
+function isImportActive(importId: string): boolean {
+  return props.activeImports.some((imp) => imp.id === importId)
 }
 
 // Toggle an import (single select mode)
-function toggleImport(importItem: Import): void {
-  let newImports: Import[] = []
+function toggleImport(importItem: DashboardImport): void {
+  let newImports: DashboardImport[] = []
 
   if (isImportActive(importItem.name)) {
     // If already active, deselect it (empty array)
     newImports = []
   } else {
     // If not active, select only this one
-    newImports = [{ name: importItem.name, alias: '' }]
+    newImports = [{ name: importItem.name, alias: importItem.alias, id: importItem.id }]
   }
 
   emit('update:imports', newImports)
@@ -137,15 +137,15 @@ onUnmounted(() => {
       <div class="import-list">
         <div
           v-for="importItem in availableImports"
-          :key="importItem.name"
+          :key="importItem.id"
           class="import-item"
-          :class="{ active: isImportActive(importItem.name) }"
+          :class="{ active: isImportActive(importItem.id) }"
           @click="toggleImport(importItem)"
           :data-testid="`set-dashboard-source-${importItem.name}`"
         >
           <div class="import-checkbox">
             <svg
-              v-if="isImportActive(importItem.name)"
+              v-if="isImportActive(importItem.id)"
               xmlns="http://www.w3.org/2000/svg"
               width="16"
               height="16"

--- a/lib/components/DashboardTable.vue
+++ b/lib/components/DashboardTable.vue
@@ -48,8 +48,9 @@ import QueryExecutionService from '../stores/queryExecutionService'
 import ErrorMessage from './ErrorMessage.vue'
 import DataTable from './DataTable.vue'
 import LoadingView from './LoadingView.vue'
-import { type GridItemData, type DimensionClick } from '../dashboards/base'
+import { type GridItemDataResponse, type DimensionClick } from '../dashboards/base'
 import { type AnalyticsStoreType } from '../stores/analyticsStore'
+
 export default defineComponent({
   name: 'DashboardChart',
   components: {
@@ -67,7 +68,7 @@ export default defineComponent({
       required: true,
     },
     getItemData: {
-      type: Function as PropType<(itemId: string, dashboardId: string) => GridItemData>,
+      type: Function as PropType<(itemId: string, dashboardId: string) => GridItemDataResponse>,
       required: true,
       default: () => ({ type: 'CHART', content: '' }),
     },
@@ -131,6 +132,10 @@ export default defineComponent({
       return itemData.onRefresh || null
     })
 
+    const rootContent = computed(() => {
+      return props.getItemData(props.itemId, props.dashboardId).rootContent || []
+    })
+
     const connectionStore = inject<ConnectionStoreType>('connectionStore')
     const queryExecutionService = inject<QueryExecutionService>('queryExecutionService')
     const analyticsStore = inject<AnalyticsStoreType>('analyticsStore')
@@ -162,6 +167,7 @@ export default defineComponent({
         const conn = connectionStore.connections[connName]
 
         // Create query input object using the chart's query content
+        console.log(rootContent.value)
         const queryInput = {
           text: query.value,
           queryType: conn.query_type,
@@ -169,6 +175,7 @@ export default defineComponent({
           imports: chartImports.value,
           extraFilters: filters.value,
           parameters: chartParameters.value,
+          extraContent: rootContent.value,
         }
 
         // Get the query execution service from the provider

--- a/lib/components/Editor.vue
+++ b/lib/components/Editor.vue
@@ -239,6 +239,13 @@ export default defineComponent({
             )
             this.$emit('save-models')
           }
+        } else {
+          // If it's a source, we need to remove it from the model
+          let model = this.connectionStore.connections[this.editorData.connection].model
+          if (model) {
+            this.modelStore.models[model].removeModelSourceSimple(this.editorData.id)
+            this.$emit('save-models')
+          }
         }
       }
       this.editorData.tags = this.editorData.tags.includes(tag)

--- a/lib/dashboards/barChartSpec.ts
+++ b/lib/dashboards/barChartSpec.ts
@@ -6,6 +6,7 @@ import {
   createInteractionEncodings,
   getSortOrder,
 } from './helpers'
+import { lightDefaultColor, darkDefaultColor } from './constants'
 
 export const createBarChartSpec = (
   config: ChartConfig,
@@ -14,6 +15,7 @@ export const createBarChartSpec = (
   encoding: any,
   data: readonly Row[] | null,
   intChart: Array<Partial<ChartConfig>>,
+  currentTheme: 'light' | 'dark' | '' = 'light',
 ) => {
   // Determine the number of unique values in the x-field
   let xValueCount = 0
@@ -51,7 +53,10 @@ export const createBarChartSpec = (
         nearest: true,
       },
     ],
-    mark: 'bar',
+    mark: {
+      type: 'bar',
+      color: currentTheme === 'light' ? lightDefaultColor : darkDefaultColor,
+    },
     encoding: {
       x: {
         ...createFieldEncoding(config.xField || '', columns, { axis: { labelAngle } }),

--- a/lib/dashboards/barHChartSpec.ts
+++ b/lib/dashboards/barHChartSpec.ts
@@ -1,0 +1,57 @@
+import { type ResultColumn } from '../editors/results'
+import { type ChartConfig } from '../editors/results'
+import { getColumnFormat, createFieldEncoding, createInteractionEncodings } from './helpers'
+import { lightDefaultColor, darkDefaultColor } from './constants'
+
+export const createBarHChartSpec = (
+  config: ChartConfig,
+  columns: Map<string, ResultColumn>,
+  tooltipFields: any[],
+  encoding: any,
+  isMobile: boolean,
+  intChart: Array<Partial<ChartConfig>>,
+  currentTheme: string = 'light',
+) => {
+  return {
+    params: [
+      {
+        name: 'highlight',
+        select: {
+          type: 'point',
+          on: 'mouseover',
+          clear: 'mouseout',
+        },
+      },
+      {
+        name: 'select',
+        select: {
+          type: 'point',
+          on: 'click,touchend',
+        },
+        value: intChart,
+        nearest: true,
+      },
+    ],
+    mark: {
+      type: 'bar',
+      color: currentTheme === 'light' ? lightDefaultColor : darkDefaultColor,
+    },
+    encoding: {
+      y: {
+        ...createFieldEncoding(config.yField || '', columns),
+        sort: '-x',
+        axis: {
+          labelExpr: isMobile
+            ? "datum.label.length > 13 ? slice(datum.label, 0, 10) + '...' : datum.label"
+            : 'datum.label',
+        },
+      },
+      x: createFieldEncoding(config.xField || '', columns, {
+        axis: { format: getColumnFormat(config.xField, columns) },
+      }),
+      ...createInteractionEncodings(),
+      tooltip: tooltipFields,
+      ...encoding,
+    },
+  }
+}

--- a/lib/dashboards/base.ts
+++ b/lib/dashboards/base.ts
@@ -1,12 +1,18 @@
 // Define types for dashboard layouts
 import type { ChartConfig } from '../editors/results'
-import type { Import } from '../stores/resolver'
+
 import { objectToSqlExpression } from './conditions'
+import type { ContentInput } from '../stores/resolver'
 export interface DimensionClick {
   source: string
   filters: Record<string, string>
   chart: Record<string, string>
   append: boolean
+}
+export interface DashboardImport {
+  id: string
+  name: string
+  alias: string
 }
 
 export interface LayoutItem {
@@ -34,8 +40,22 @@ export interface GridItemData {
   width?: number
   height?: number
   chartConfig?: ChartConfig
+  conceptFilters?: FilterInput[]
+  chartFilters?: FilterInput[]
+  filters?: Filter[]
+  parameters?: Record<string, unknown>
+}
+
+export interface GridItemDataResponse {
+  type: 'chart' | 'markdown' | 'table'
+  content: string
+  rootContent: ContentInput[]
+  name: string
+  width?: number
+  height?: number
+  chartConfig?: ChartConfig
   connectionName?: string
-  imports?: Import[]
+  imports?: DashboardImport[]
   conceptFilters?: FilterInput[]
   chartFilters?: FilterInput[]
   filters?: Filter[]
@@ -54,7 +74,7 @@ export interface Dashboard {
   createdAt: Date
   updatedAt: Date
   filter: string | null
-  imports: Import[]
+  imports: DashboardImport[]
   version: number
   description: string
   state: 'editing' | 'published' | 'locked'
@@ -81,7 +101,7 @@ export class DashboardModel implements Dashboard {
   createdAt: Date
   updatedAt: Date
   filter: string | null = null
-  imports: Import[] = []
+  imports: DashboardImport[] = []
   version: number
   state: 'editing' | 'published' | 'locked' = 'editing'
   description: string = ''

--- a/lib/dashboards/conditions.ts
+++ b/lib/dashboards/conditions.ts
@@ -78,7 +78,7 @@ function formatValue(value: unknown) {
   // Handle string values
   if (typeof value === 'string') {
     // Escape single quotes in strings
-    const escapedValue = value.replace(/'/g, "''")
+    const escapedValue = value.replace(/'/g, "\\'")
     return `'${escapedValue}'`
   }
   // Handle boolean values
@@ -97,7 +97,7 @@ function formatCondition(key: string, value: unknown): string {
     return `${key} IS NULL`
   } else if (typeof value === 'string') {
     // Escape single quotes in strings
-    const escapedValue = value.replace(/'/g, "''")
+    const escapedValue = value.replace(/'/g, "\\'")
     return `${key}='''${escapedValue}'''`
   } else if (Array.isArray(value)) {
     // Handle array values
@@ -108,7 +108,7 @@ function formatCondition(key: string, value: unknown): string {
     return `${key} IS NULL`
   } else {
     // For complex objects, arrays, etc. - convert to JSON string
-    const escapedValue = JSON.stringify(value).replace(/'/g, "''")
+    const escapedValue = JSON.stringify(value).replace(/'/g, "\\'")
     return `${key}='${escapedValue}'`
   }
 }

--- a/lib/dashboards/donutSpec.ts
+++ b/lib/dashboards/donutSpec.ts
@@ -8,6 +8,7 @@ export const createDonutChartSpec = (
   tooltipFields: any[],
   encoding: any,
   intChart: Array<Partial<ChartConfig>>,
+  currentTheme: string = 'light',
 ) => {
   let donutLayer = {
     params: [
@@ -60,13 +61,35 @@ export const createDonutChartSpec = (
     },
   }
   let labelLayer = {
-    mark: { type: 'text', radius: 85, fill: 'white', fontWeight: 'bold' },
+    transform: [
+      {
+        window: [{ op: 'sum', field: config.yField, as: 'total' }],
+      },
+      {
+        calculate: `datum.${config.yField} / datum.total`,
+        as: 'angle_pct',
+      },
+      {
+        filter: 'datum.angle_pct > 0.05',
+      },
+    ],
+    mark: {
+      type: 'text',
+      radius: 85,
+      color: currentTheme === 'light' ? 'black' : 'white',
+      fontSize: 10,
+    },
     encoding: {
-      theta: { field: config.yField, type: 'quantitative', stack: true },
+      theta: {
+        field: config.yField,
+        type: 'quantitative',
+        stack: true,
+      },
       text: { field: config.xField, type: 'nominal' },
       order: { field: config.yField, sort: 'descending' },
     },
   }
+
   return {
     layer: [donutLayer, labelLayer],
   }

--- a/lib/models/model.ts
+++ b/lib/models/model.ts
@@ -383,6 +383,11 @@ export class ModelConfig {
     this.addModelSource(new ModelSource(editor, alias, [], []))
   }
 
+  removeModelSourceSimple(editor: string) {
+    this.sources = this.sources.filter((s) => s.editor !== editor)
+    this.changed = true
+  }
+
   updateModelSourceName(id: string, newName: string) {
     let source = this.sources.find((s) => s.editor === id)
     if (source) {

--- a/lib/stores/dashboardStore.ts
+++ b/lib/stores/dashboardStore.ts
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia'
-import type { LayoutItem, CellType } from '../dashboards/base'
+import type { LayoutItem, CellType, DashboardImport } from '../dashboards/base'
 import { CELL_TYPES, DashboardModel } from '../dashboards/base'
-import type { Import } from './resolver'
 import { type PromptDashboard, parseDashboardSpec } from '../dashboards/prompts'
 import type { LLMConnectionStoreType } from './llmStore'
 import type QueryExecutionService from './queryExecutionService'
@@ -168,7 +167,10 @@ export const useDashboardStore = defineStore('dashboards', {
       }
     },
 
-    updateDashboardImports(id: string, imports: Import[]) {
+    updateDashboardImports(id: string, imports: DashboardImport[]) {
+      console.log('Updating imports for dashboard:', id)
+      console.log('New imports:', imports)
+
       if (this.dashboards[id]) {
         this.dashboards[id].imports = imports
       } else {

--- a/lib/stores/queryExecutionService.ts
+++ b/lib/stores/queryExecutionService.ts
@@ -503,9 +503,7 @@ export default class QueryExecutionService {
       conn && conn.model
         ? this.modelStore.models[conn.model].sources.map((source) => ({
             alias: source.alias,
-            contents: this.editorStore.editors[source.editor]
-              ? this.editorStore.editors[source.editor].contents
-              : '',
+            contents: this.editorStore.editors[source.editor]?.contents || '',
           }))
         : []
     if (queryInput.extraContent) {

--- a/lib/stores/userSettingsStore.ts
+++ b/lib/stores/userSettingsStore.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 import { useAnalyticsStore } from './analyticsStore'
 
 export interface UserSettings {
-  theme: string
+  theme: 'dark' | 'light' | ''
   trilogyResolver: string
   telemetryEnabled: boolean | null
   [key: string]: string | boolean | number | null | undefined


### PR DESCRIPTION
Dashboard import management only worked for sources and relied on name, not ID.

Refactor to be resilient to duplicate names and actually support arbitrary sources.

Some misc donut chart polish followup.