### PR TITLE
Dashboard caching

### DIFF
--- a/lib/components/DashboardBase.vue
+++ b/lib/components/DashboardBase.vue
@@ -403,6 +403,7 @@ function getItemData(itemId: string, dashboardId: string): GridItemDataResponse 
     parameters: item.parameters || {},
     onRefresh: handleRefresh,
     rootContent: rootContent.value,
+    results: item.results || null,
   }
 }
 
@@ -429,6 +430,9 @@ function setItemData(itemId: string, dashboardId: string, data: any): void {
 
   if (data.width && data.height) {
     dashboardStore.updateItemDimensions(dashboard.value.id, itemId, data.width, data.height)
+  }
+  if (data.results) {
+    dashboardStore.updateItemResults(dashboard.value.id, itemId, data.results)
   }
 }
 

--- a/lib/components/DashboardHeader.vue
+++ b/lib/components/DashboardHeader.vue
@@ -6,10 +6,11 @@ import DashboardSharePopup from './DashboardSharePopup.vue'
 import FilterInputComponent from './DashboardHeaderFilterInput.vue'
 import { type CompletionItem } from '../stores/resolver'
 import { type DashboardImport } from '../dashboards/base'
+import { type Dashboard } from '../dashboards/base'
 
 const props = defineProps({
   dashboard: {
-    type: Object,
+    type: Object as () => Dashboard,
     required: true,
   },
   editMode: Boolean,

--- a/lib/components/DashboardSharePopup.vue
+++ b/lib/components/DashboardSharePopup.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import { type Dashboard } from '../dashboards/base'
 const props = defineProps<{
-  dashboard: object | null
+  dashboard: Dashboard | null
   isOpen: boolean
 }>()
 const emit = defineEmits<{
@@ -11,7 +12,7 @@ const emit = defineEmits<{
 const jsonString = ref<string>('')
 
 // Function to filter out unwanted properties
-const filterDashboard = (dashboard: any): any => {
+const filterDashboard = (dashboard: Dashboard): any => {
   if (!dashboard) return null
 
   // Create a deep copy to avoid modifying the original
@@ -30,6 +31,18 @@ const filterDashboard = (dashboard: any): any => {
       delete itemCopy.moved
       return itemCopy
     })
+  }
+
+  // Iterate over gridItems: Record<string, GridItemData> and remove results objects
+  if (dashboardCopy.gridItems && typeof dashboardCopy.gridItems === 'object') {
+    for (const [itemId, gridItem] of Object.entries(dashboardCopy.gridItems)) {
+      const itemCopy = { ...(gridItem as any) }
+      delete itemCopy.results
+      if (itemCopy.chartConfig) {
+        delete itemCopy.chartConfig.showDebug
+      }
+      dashboardCopy.gridItems[itemId] = itemCopy
+    }
   }
 
   return dashboardCopy

--- a/lib/components/DashboardTable.vue
+++ b/lib/components/DashboardTable.vue
@@ -83,7 +83,6 @@ export default defineComponent({
     },
   },
   setup(props, { emit }) {
-    const results = ref<Results | null>(null)
     const loading = ref(false)
     const error = ref<string | null>(null)
     const startTime = ref<number | null>(null)
@@ -95,7 +94,9 @@ export default defineComponent({
     const query = computed(() => {
       return props.getItemData(props.itemId, props.dashboardId).content
     })
-
+    const results = computed(() => {
+      return props.getItemData(props.itemId, props.dashboardId).results || null
+    })
     const chartHeight = computed(() => {
       return (props.getItemData(props.itemId, props.dashboardId).height || 300) - 75
     })
@@ -202,7 +203,9 @@ export default defineComponent({
 
         // Update component state based on result
         if (result.success && result.results) {
-          results.value = result.results
+          props.setItemData(props.itemId, props.dashboardId, {
+            results: result.results as Results,
+          })
           error.value = null
         } else if (result.error) {
           error.value = result.error

--- a/lib/components/VegaLiteChart.vue
+++ b/lib/components/VegaLiteChart.vue
@@ -348,7 +348,6 @@ export default defineComponent({
       xField: '',
       yField: '',
       yField2: '',
-      yAggregation: 'sum',
       colorField: '',
       sizeField: '',
       groupField: '',
@@ -558,7 +557,7 @@ export default defineComponent({
       lastSpec.value = currentSpecString
       try {
         await vegaEmbed(vegaContainer.value, spec, {
-          actions: internalConfig.value.showDebug,
+          actions: internalConfig.value.showDebug ? true : false,
           theme: currentTheme.value === 'dark' ? 'dark' : undefined,
           renderer: 'canvas', // Use canvas renderer for better performance with large datasets
         }).then((result) => {
@@ -614,7 +613,7 @@ export default defineComponent({
         internalConfig.value.xField = configDefaults.xField
         internalConfig.value.yField = configDefaults.yField
         internalConfig.value.yField2 = configDefaults.yField2
-        internalConfig.value.yAggregation = configDefaults.yAggregation
+
         internalConfig.value.colorField = configDefaults.colorField
         internalConfig.value.sizeField = configDefaults.sizeField
         internalConfig.value.groupField = configDefaults.groupField

--- a/lib/editors/results.ts
+++ b/lib/editors/results.ts
@@ -77,7 +77,6 @@ export interface ChartConfig {
   xField?: string
   yField?: string
   yField2?: string
-  yAggregation?: string
   colorField?: string
   sizeField?: string
   groupField?: string

--- a/lib/stores/dashboardStore.ts
+++ b/lib/stores/dashboardStore.ts
@@ -8,6 +8,7 @@ import type { QueryInput } from './queryExecutionService'
 import type { ModelConceptInput } from '../llm'
 import { completionToModelInput } from '../llm/utils'
 import type { EditorStoreType } from './editorStore'
+import type { Results } from '../editors/results'
 
 interface ContentPlaceholder {
   type: 'markdown' | 'chart' | 'table'
@@ -220,6 +221,18 @@ export const useDashboardStore = defineStore('dashboards', {
     updateItemContent(dashboardId: string, itemId: string, content: string) {
       if (this.dashboards[dashboardId]) {
         this.dashboards[dashboardId].updateItemContent(itemId, content)
+      } else {
+        throw new Error(`Dashboard with ID "${dashboardId}" not found.`)
+      }
+    },
+
+    updateItemResults(
+      dashboardId: string,
+      itemId: string,
+      results: Results, // Assuming results can be of any type, adjust as needed
+    ) {
+      if (this.dashboards[dashboardId]) {
+        this.dashboards[dashboardId].updateItemResults(itemId, results)
       } else {
         throw new Error(`Dashboard with ID "${dashboardId}" not found.`)
       }


### PR DESCRIPTION
Locally cache dashboard results to avoid needing to rerun queries on navigation/return. 

Strip cached values from serialization/exports. 