### PR TITLE
[Bug]: Fix demo deep link stranding on welcome screen

### DIFF
--- a/e2e/test-trilogy-editor.spec.ts
+++ b/e2e/test-trilogy-editor.spec.ts
@@ -62,7 +62,51 @@ select unnest(x) as rows;
 test('test_demo_deep_link', async ({ page }) => {
   // #demo=true lands directly in a connected demo editor with no clicks
   await page.goto('#skipTips=true&demo=true')
-  await page.getByTestId('editor-run-button').click()
+  await runEditorQueryAndExpectCount(page, 4, 120000)
+  await page.getByRole('gridcell', { name: 'R' }).click()
+})
+
+test('test_demo_deep_link_with_persisted_state', async ({ page, isMobile }) => {
+  // Regression: the demo bootstrap must not race persisted-workspace
+  // hydration. A revisit with existing IndexedDB/localStorage data hydrates
+  // stores asynchronously; running the deep link before hydration finishes
+  // used to let hydration clobber the fresh demo connection (or duplicate the
+  // demo workspace) on mobile, which skipped the storesLoaded guard.
+  await page.goto('#skipTips=true&demo=true')
+  await runEditorQueryAndExpectCount(page, 4, 120000)
+
+  // Revisit: cold document load with the deep link AND persisted state.
+  // replaceState avoids firing hashchange before the reload so this exercises
+  // the mounted() bootstrap path, not the hashchange relaunch path.
+  await page.evaluate(() => {
+    window.history.replaceState(null, '', '#skipTips=true&demo=true')
+  })
+  await page.reload()
+  await runEditorQueryAndExpectCount(page, 4, 120000)
+
+  // The repeat bootstrap reused the existing workspace: exactly one demo editor
+  await openSidebarScreen(page, 'editors', isMobile)
+  if (isMobile) {
+    await drillMobileTree(page, ['Browser Storage', 'demo-model-connection'])
+  }
+  await expect(
+    page.getByTestId(
+      `editor-e-local-${localConnectionId('demo-model-connection')}-tutorial_one_basic`,
+    ),
+  ).toHaveCount(1)
+})
+
+test('test_demo_deep_link_same_document', async ({ page }) => {
+  // Regression: navigating to #demo=true while the app is ALREADY loaded
+  // (Safari restoring a tab, tapping the link twice) is a same-document
+  // navigation — mounted never re-runs. The demo must still launch from the
+  // hashchange, not strand the user on the welcome screen with a spinner.
+  await page.goto('#skipTips=true')
+  await expect(page.getByTestId('demo-editor-button')).toBeVisible()
+
+  // Only the hash differs, so this does not reload the document
+  await page.goto('#skipTips=true&demo=true')
+  await runEditorQueryAndExpectCount(page, 4, 120000)
   await page.getByRole('gridcell', { name: 'R' }).click()
 })
 

--- a/lib/stores/Manager.vue
+++ b/lib/stores/Manager.vue
@@ -458,7 +458,11 @@ for (let source of props.storageSources) {
   )
 }
 
-// Wait for all promises to resolve, then set loaded to true
+// Wait for all promises to settle, then set loaded to true. `loaded` flips in
+// finally: consumers gate bootstrap logic (e.g. the #demo=true deep link) on
+// it, so a hydration failure must not leave them waiting forever — they
+// proceed with whatever did load, and the error is exposed separately.
+const hydrationError = ref<unknown>(null)
 Promise.all(loadingPromises)
   .then(() => {
     // One-time backfill for entities persisted before connectionId existed.
@@ -484,11 +488,13 @@ Promise.all(loadingPromises)
         }
       }
     }
-    loaded.value = true
   })
   .catch((error) => {
-    console.error('Error loading editor data:', error)
-    // You might want to handle the error state appropriately
+    console.error('Error loading workspace data:', error)
+    hydrationError.value = error
+  })
+  .finally(() => {
+    loaded.value = true
   })
 
 const saveEditors = async () => {
@@ -709,4 +715,7 @@ provide('isMobile', isMobile)
 // Expose the hydration flag so views can defer bootstrap logic (e.g. the
 // #demo=true deep link) until persisted state has finished loading.
 provide('storesLoaded', loaded)
+// Non-null when hydration partially failed; loaded still flips true so
+// consumers never hang, but they can surface a workspace-loading warning.
+provide('storesLoadError', hydrationError)
 </script>

--- a/lib/views/IDE.vue
+++ b/lib/views/IDE.vue
@@ -153,10 +153,9 @@
         </template>
         <template v-else>
           <welcome-page
-            :demo-error="demoLaunchError"
             @screen-selected="setActiveScreen"
             @sidebar-screen-selected="setActiveSidebarScreen"
-            @demo-started="launchDemo"
+            @demo-started="startDemo"
             @documentation-key-selected="setActiveDocumentationKey"
           />
         </template>
@@ -296,10 +295,6 @@ const IDEComponent: Component = defineComponent({
   data() {
     return {
       activeTab: 'results',
-      // Demo deep-link launch state; error is surfaced on the welcome page.
-      demoLaunchInFlight: false,
-      demoLaunchError: '',
-      demoHashListener: null as (() => void) | null,
     }
   },
   props: {
@@ -560,21 +555,15 @@ const IDEComponent: Component = defineComponent({
   },
   async mounted() {
     // #demo=true deep link: land directly in the demo editor, connected.
-    // Also listen for hashchange: navigating to the demo link while the app is
-    // already loaded (Safari restoring a tab, tapping the link twice) is a
-    // same-document navigation — mounted never re-runs, and without this the
-    // hashchange handler in useScreenNavigation resets to the welcome screen
-    // and the demo never launches, stranding the user on an endless spinner.
-    this.demoHashListener = () => {
-      this.maybeStartDemoFromHash()
-    }
-    window.addEventListener('hashchange', this.demoHashListener)
-    await this.maybeStartDemoFromHash()
-  },
-  beforeUnmount() {
-    if (this.demoHashListener) {
-      window.removeEventListener('hashchange', this.demoHashListener)
-      this.demoHashListener = null
+    if (getDefaultValueFromHash(URL_HASH_KEYS.DEMO, '') === 'true') {
+      // Wait for persisted state to hydrate first; running the demo setup
+      // before loadConnections finishes would let hydration overwrite the
+      // freshly-created (and connecting) demo connection, leaving it
+      // disconnected. It also lets setupDemo's idempotency check see any
+      // existing demo editor and reuse it instead of recreating it.
+      await this.waitForStoresLoaded()
+      await this.startDemo()
+      removeHashFromUrl(URL_HASH_KEYS.DEMO)
     }
   },
   methods: {
@@ -619,33 +608,6 @@ const IDEComponent: Component = defineComponent({
           },
         )
       })
-    },
-    maybeStartDemoFromHash(): Promise<void> {
-      if (getDefaultValueFromHash(URL_HASH_KEYS.DEMO, '') !== 'true') return Promise.resolve()
-      return this.launchDemo()
-    },
-    // Guarded wrapper: single-flight, waits for hydration, and surfaces
-    // failures on the welcome page instead of dying as an unhandled rejection
-    // with the splash spinner running forever.
-    async launchDemo() {
-      if (this.demoLaunchInFlight) return
-      this.demoLaunchInFlight = true
-      this.demoLaunchError = ''
-      try {
-        // Wait for persisted state to hydrate first; running the demo setup
-        // before loadConnections finishes would let hydration overwrite the
-        // freshly-created (and connecting) demo connection, leaving it
-        // disconnected. It also lets setupDemo's idempotency check see any
-        // existing demo editor and reuse it instead of recreating it.
-        await this.waitForStoresLoaded()
-        await this.startDemo()
-        removeHashFromUrl(URL_HASH_KEYS.DEMO)
-      } catch (error) {
-        console.error('Demo setup failed:', error)
-        this.demoLaunchError = error instanceof Error ? error.message : String(error)
-      } finally {
-        this.demoLaunchInFlight = false
-      }
     },
     async startDemo() {
       let editor = await setupDemo(

--- a/lib/views/IDE.vue
+++ b/lib/views/IDE.vue
@@ -153,9 +153,10 @@
         </template>
         <template v-else>
           <welcome-page
+            :demo-error="demoLaunchError"
             @screen-selected="setActiveScreen"
             @sidebar-screen-selected="setActiveSidebarScreen"
-            @demo-started="startDemo"
+            @demo-started="launchDemo"
             @documentation-key-selected="setActiveDocumentationKey"
           />
         </template>
@@ -295,6 +296,10 @@ const IDEComponent: Component = defineComponent({
   data() {
     return {
       activeTab: 'results',
+      // Demo deep-link launch state; error is surfaced on the welcome page.
+      demoLaunchInFlight: false,
+      demoLaunchError: '',
+      demoHashListener: null as (() => void) | null,
     }
   },
   props: {
@@ -555,15 +560,21 @@ const IDEComponent: Component = defineComponent({
   },
   async mounted() {
     // #demo=true deep link: land directly in the demo editor, connected.
-    if (getDefaultValueFromHash(URL_HASH_KEYS.DEMO, '') === 'true') {
-      // Wait for persisted state to hydrate first; running the demo setup
-      // before loadConnections finishes would let hydration overwrite the
-      // freshly-created (and connecting) demo connection, leaving it
-      // disconnected. It also lets setupDemo's idempotency check see any
-      // existing demo editor and reuse it instead of recreating it.
-      await this.waitForStoresLoaded()
-      await this.startDemo()
-      removeHashFromUrl(URL_HASH_KEYS.DEMO)
+    // Also listen for hashchange: navigating to the demo link while the app is
+    // already loaded (Safari restoring a tab, tapping the link twice) is a
+    // same-document navigation — mounted never re-runs, and without this the
+    // hashchange handler in useScreenNavigation resets to the welcome screen
+    // and the demo never launches, stranding the user on an endless spinner.
+    this.demoHashListener = () => {
+      this.maybeStartDemoFromHash()
+    }
+    window.addEventListener('hashchange', this.demoHashListener)
+    await this.maybeStartDemoFromHash()
+  },
+  beforeUnmount() {
+    if (this.demoHashListener) {
+      window.removeEventListener('hashchange', this.demoHashListener)
+      this.demoHashListener = null
     }
   },
   methods: {
@@ -608,6 +619,33 @@ const IDEComponent: Component = defineComponent({
           },
         )
       })
+    },
+    maybeStartDemoFromHash(): Promise<void> {
+      if (getDefaultValueFromHash(URL_HASH_KEYS.DEMO, '') !== 'true') return Promise.resolve()
+      return this.launchDemo()
+    },
+    // Guarded wrapper: single-flight, waits for hydration, and surfaces
+    // failures on the welcome page instead of dying as an unhandled rejection
+    // with the splash spinner running forever.
+    async launchDemo() {
+      if (this.demoLaunchInFlight) return
+      this.demoLaunchInFlight = true
+      this.demoLaunchError = ''
+      try {
+        // Wait for persisted state to hydrate first; running the demo setup
+        // before loadConnections finishes would let hydration overwrite the
+        // freshly-created (and connecting) demo connection, leaving it
+        // disconnected. It also lets setupDemo's idempotency check see any
+        // existing demo editor and reuse it instead of recreating it.
+        await this.waitForStoresLoaded()
+        await this.startDemo()
+        removeHashFromUrl(URL_HASH_KEYS.DEMO)
+      } catch (error) {
+        console.error('Demo setup failed:', error)
+        this.demoLaunchError = error instanceof Error ? error.message : String(error)
+      } finally {
+        this.demoLaunchInFlight = false
+      }
     },
     async startDemo() {
       let editor = await setupDemo(

--- a/lib/views/MobileIDE.vue
+++ b/lib/views/MobileIDE.vue
@@ -123,7 +123,11 @@
         <LLMView :initialTab="llmInitialTab" />
       </template>
       <template v-else>
-        <welcome-page @screen-selected="setActiveScreen" @demo-started="startDemo" />
+        <welcome-page
+          :demo-error="demoLaunchError"
+          @screen-selected="setActiveScreen"
+          @demo-started="launchDemo"
+        />
       </template>
     </mobile-sidebar-layout>
   </div>
@@ -178,7 +182,8 @@ import { EditorTag } from '../editors'
 import type { ConnectionStoreType } from '../stores/connectionStore.ts'
 import TrilogyResolver from '../stores/resolver.ts'
 import type QueryExecutionService from '../stores/queryExecutionService.ts'
-import { inject, defineAsyncComponent, provide, onBeforeUnmount, onMounted, ref } from 'vue'
+import { inject, defineAsyncComponent, provide, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import type { Ref } from 'vue'
 
 import setupDemo from '../data/tutorial/demoSetup'
 import { getDefaultValueFromHash, removeHashFromUrl, URL_HASH_KEYS } from '../stores/urlStore.ts'
@@ -213,7 +218,12 @@ export interface MobileIDEProps {}
 const MobileIDEComponent: Component = defineComponent({
   name: 'MobileIDEComponent',
   data() {
-    return {}
+    return {
+      // Demo deep-link launch state; error is surfaced on the welcome page.
+      demoLaunchInFlight: false,
+      demoLaunchError: '',
+      demoHashListener: null as (() => void) | null,
+    }
   },
   components: {
     Sidebar,
@@ -247,6 +257,9 @@ const MobileIDEComponent: Component = defineComponent({
     let dashboardStore = inject<DashboardStoreType>('dashboardStore')
     const trilogyResolver = inject<ResolverType>('trilogyResolver')
     const queryExecutionService = inject<QueryExecutionService>('queryExecutionService')
+    // Hydration flag from Manager; the demo deep link waits on it so it doesn't
+    // race persisted state loading and get clobbered by loadConnections.
+    const storesLoaded = inject<Ref<boolean>>('storesLoaded', ref(true))
     let saveEditors = inject<Function>('saveEditors')
     let saveConnections = inject<Function>('saveConnections')
     let saveModels = inject<Function>('saveModels')
@@ -392,6 +405,7 @@ const MobileIDEComponent: Component = defineComponent({
     return {
       connectionStore,
       editorStore,
+      storesLoaded,
       dashboardStore,
       trilogyResolver,
       queryExecutionService,
@@ -451,9 +465,21 @@ const MobileIDEComponent: Component = defineComponent({
   },
   async mounted() {
     // #demo=true deep link: land directly in the demo editor, connected.
-    if (getDefaultValueFromHash(URL_HASH_KEYS.DEMO, '') === 'true') {
-      await this.startDemo()
-      removeHashFromUrl(URL_HASH_KEYS.DEMO)
+    // Also listen for hashchange: navigating to the demo link while the app is
+    // already loaded (Safari restoring a tab, tapping the link twice) is a
+    // same-document navigation — mounted never re-runs, and without this the
+    // hashchange handler in useScreenNavigation resets to the welcome screen
+    // and the demo never launches, stranding the user on an endless spinner.
+    this.demoHashListener = () => {
+      this.maybeStartDemoFromHash()
+    }
+    window.addEventListener('hashchange', this.demoHashListener)
+    await this.maybeStartDemoFromHash()
+  },
+  beforeUnmount() {
+    if (this.demoHashListener) {
+      window.removeEventListener('hashchange', this.demoHashListener)
+      this.demoHashListener = null
     }
   },
   methods: {
@@ -497,6 +523,45 @@ const MobileIDEComponent: Component = defineComponent({
     },
     saveEditorsCall() {
       this.saveEditors()
+    },
+    waitForStoresLoaded(): Promise<void> {
+      if (this.storesLoaded) return Promise.resolve()
+      return new Promise((resolve) => {
+        const stop = watch(
+          () => this.storesLoaded,
+          (loaded) => {
+            if (loaded) {
+              stop()
+              resolve()
+            }
+          },
+        )
+      })
+    },
+    maybeStartDemoFromHash(): Promise<void> {
+      if (getDefaultValueFromHash(URL_HASH_KEYS.DEMO, '') !== 'true') return Promise.resolve()
+      return this.launchDemo()
+    },
+    // Guarded wrapper: single-flight, waits for hydration, and surfaces
+    // failures on the welcome page instead of dying as an unhandled rejection
+    // with the splash spinner running forever.
+    async launchDemo() {
+      if (this.demoLaunchInFlight) return
+      this.demoLaunchInFlight = true
+      this.demoLaunchError = ''
+      try {
+        // Wait for persisted state to hydrate first (parity with IDE.vue);
+        // running the demo setup before loadConnections finishes would let
+        // hydration overwrite the freshly-created demo connection.
+        await this.waitForStoresLoaded()
+        await this.startDemo()
+        removeHashFromUrl(URL_HASH_KEYS.DEMO)
+      } catch (error) {
+        console.error('Demo setup failed:', error)
+        this.demoLaunchError = error instanceof Error ? error.message : String(error)
+      } finally {
+        this.demoLaunchInFlight = false
+      }
     },
     async startDemo() {
       let editorId = await setupDemo(

--- a/lib/views/MobileIDE.vue
+++ b/lib/views/MobileIDE.vue
@@ -123,11 +123,7 @@
         <LLMView :initialTab="llmInitialTab" />
       </template>
       <template v-else>
-        <welcome-page
-          :demo-error="demoLaunchError"
-          @screen-selected="setActiveScreen"
-          @demo-started="launchDemo"
-        />
+        <welcome-page @screen-selected="setActiveScreen" @demo-started="startDemo" />
       </template>
     </mobile-sidebar-layout>
   </div>
@@ -182,8 +178,7 @@ import { EditorTag } from '../editors'
 import type { ConnectionStoreType } from '../stores/connectionStore.ts'
 import TrilogyResolver from '../stores/resolver.ts'
 import type QueryExecutionService from '../stores/queryExecutionService.ts'
-import { inject, defineAsyncComponent, provide, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import type { Ref } from 'vue'
+import { inject, defineAsyncComponent, provide, onBeforeUnmount, onMounted, ref } from 'vue'
 
 import setupDemo from '../data/tutorial/demoSetup'
 import { getDefaultValueFromHash, removeHashFromUrl, URL_HASH_KEYS } from '../stores/urlStore.ts'
@@ -218,12 +213,7 @@ export interface MobileIDEProps {}
 const MobileIDEComponent: Component = defineComponent({
   name: 'MobileIDEComponent',
   data() {
-    return {
-      // Demo deep-link launch state; error is surfaced on the welcome page.
-      demoLaunchInFlight: false,
-      demoLaunchError: '',
-      demoHashListener: null as (() => void) | null,
-    }
+    return {}
   },
   components: {
     Sidebar,
@@ -257,9 +247,6 @@ const MobileIDEComponent: Component = defineComponent({
     let dashboardStore = inject<DashboardStoreType>('dashboardStore')
     const trilogyResolver = inject<ResolverType>('trilogyResolver')
     const queryExecutionService = inject<QueryExecutionService>('queryExecutionService')
-    // Hydration flag from Manager; the demo deep link waits on it so it doesn't
-    // race persisted state loading and get clobbered by loadConnections.
-    const storesLoaded = inject<Ref<boolean>>('storesLoaded', ref(true))
     let saveEditors = inject<Function>('saveEditors')
     let saveConnections = inject<Function>('saveConnections')
     let saveModels = inject<Function>('saveModels')
@@ -405,7 +392,6 @@ const MobileIDEComponent: Component = defineComponent({
     return {
       connectionStore,
       editorStore,
-      storesLoaded,
       dashboardStore,
       trilogyResolver,
       queryExecutionService,
@@ -465,21 +451,9 @@ const MobileIDEComponent: Component = defineComponent({
   },
   async mounted() {
     // #demo=true deep link: land directly in the demo editor, connected.
-    // Also listen for hashchange: navigating to the demo link while the app is
-    // already loaded (Safari restoring a tab, tapping the link twice) is a
-    // same-document navigation — mounted never re-runs, and without this the
-    // hashchange handler in useScreenNavigation resets to the welcome screen
-    // and the demo never launches, stranding the user on an endless spinner.
-    this.demoHashListener = () => {
-      this.maybeStartDemoFromHash()
-    }
-    window.addEventListener('hashchange', this.demoHashListener)
-    await this.maybeStartDemoFromHash()
-  },
-  beforeUnmount() {
-    if (this.demoHashListener) {
-      window.removeEventListener('hashchange', this.demoHashListener)
-      this.demoHashListener = null
+    if (getDefaultValueFromHash(URL_HASH_KEYS.DEMO, '') === 'true') {
+      await this.startDemo()
+      removeHashFromUrl(URL_HASH_KEYS.DEMO)
     }
   },
   methods: {
@@ -523,45 +497,6 @@ const MobileIDEComponent: Component = defineComponent({
     },
     saveEditorsCall() {
       this.saveEditors()
-    },
-    waitForStoresLoaded(): Promise<void> {
-      if (this.storesLoaded) return Promise.resolve()
-      return new Promise((resolve) => {
-        const stop = watch(
-          () => this.storesLoaded,
-          (loaded) => {
-            if (loaded) {
-              stop()
-              resolve()
-            }
-          },
-        )
-      })
-    },
-    maybeStartDemoFromHash(): Promise<void> {
-      if (getDefaultValueFromHash(URL_HASH_KEYS.DEMO, '') !== 'true') return Promise.resolve()
-      return this.launchDemo()
-    },
-    // Guarded wrapper: single-flight, waits for hydration, and surfaces
-    // failures on the welcome page instead of dying as an unhandled rejection
-    // with the splash spinner running forever.
-    async launchDemo() {
-      if (this.demoLaunchInFlight) return
-      this.demoLaunchInFlight = true
-      this.demoLaunchError = ''
-      try {
-        // Wait for persisted state to hydrate first (parity with IDE.vue);
-        // running the demo setup before loadConnections finishes would let
-        // hydration overwrite the freshly-created demo connection.
-        await this.waitForStoresLoaded()
-        await this.startDemo()
-        removeHashFromUrl(URL_HASH_KEYS.DEMO)
-      } catch (error) {
-        console.error('Demo setup failed:', error)
-        this.demoLaunchError = error instanceof Error ? error.message : String(error)
-      } finally {
-        this.demoLaunchInFlight = false
-      }
     },
     async startDemo() {
       let editorId = await setupDemo(

--- a/lib/views/WelcomePage.vue
+++ b/lib/views/WelcomePage.vue
@@ -30,9 +30,6 @@
             New Editor
           </button>
         </div>
-        <p v-if="demoMessage" class="demo-message" data-testid="demo-status-message">
-          {{ demoMessage }}
-        </p>
       </template>
       <div v-else>
         <editor-creator-inline :visible="showCreator" @close="showCreator = !showCreator">
@@ -43,69 +40,16 @@
 </template>
 
 <script setup lang="ts">
-import { ref, inject, computed, watch, onUnmounted } from 'vue'
+import { ref, inject, computed } from 'vue'
 import trilogyIcon from '../static/trilogy.png'
 import EditorCreatorInline from '../components/editor/EditorCreatorInline.vue'
 import type { ConnectionStoreType } from '../stores/connectionStore'
 import { getDefaultValueFromHash, URL_HASH_KEYS } from '../stores/urlStore'
 const connectionStore = inject<ConnectionStoreType>('connectionStore')
-
-const props = defineProps({
-  // Set by the parent view when the demo launch fails; stops the spinner and
-  // is shown so a failure never reads as an endless load.
-  demoError: {
-    type: String,
-    default: '',
-  },
-})
-
-const DEMO_LOADING_TIMEOUT_MS = 30000
-const demoLoading = ref(false)
-const demoTimedOut = ref(false)
-const showCreator = ref(false)
-let demoTimer: ReturnType<typeof setTimeout> | null = null
-
-// Every loading state is bounded: if the launch hasn't landed us in the demo
-// editor by the deadline, give the button back so the user can retry instead
-// of watching a spinner forever.
-const beginDemoLoading = () => {
-  demoLoading.value = true
-  demoTimedOut.value = false
-  if (demoTimer) clearTimeout(demoTimer)
-  demoTimer = setTimeout(() => {
-    demoLoading.value = false
-    demoTimedOut.value = true
-  }, DEMO_LOADING_TIMEOUT_MS)
-}
-
 // The #demo=true deep link auto-launches the demo from the IDE shell; show
 // the loading state right away so this page reads as a splash, not a stop.
-if (getDefaultValueFromHash(URL_HASH_KEYS.DEMO, '') === 'true') {
-  beginDemoLoading()
-}
-
-watch(
-  () => props.demoError,
-  (error) => {
-    if (error) {
-      demoLoading.value = false
-      if (demoTimer) clearTimeout(demoTimer)
-    }
-  },
-)
-
-onUnmounted(() => {
-  if (demoTimer) clearTimeout(demoTimer)
-})
-
-const demoMessage = computed(() => {
-  if (props.demoError) return `Demo setup failed: ${props.demoError}`
-  if (demoTimedOut.value && !demoLoading.value)
-    return 'Demo setup is taking longer than expected. Tap Demo Editor to retry.'
-  if (demoLoading.value) return 'Setting up the demo environment…'
-  return ''
-})
-
+const demoLoading = ref(getDefaultValueFromHash(URL_HASH_KEYS.DEMO, '') === 'true')
+const showCreator = ref(false)
 const emit = defineEmits([
   'demo-started',
   'sidebar-screen-selected',
@@ -113,8 +57,12 @@ const emit = defineEmits([
   'documentation-key-selected',
 ])
 const startDemo = () => {
-  beginDemoLoading()
+  demoLoading.value = true
+
   emit('demo-started')
+  setTimeout(() => {
+    demoLoading.value = false
+  }, 30000)
 }
 
 const hasConnections = computed(() => {
@@ -250,12 +198,6 @@ h1 {
 
 .btn-tertiary:hover {
   background-color: #545b62;
-}
-
-.demo-message {
-  margin-top: 16px;
-  font-size: 14px;
-  color: var(--text-faint, #6c757d);
 }
 
 .spinner {

--- a/lib/views/WelcomePage.vue
+++ b/lib/views/WelcomePage.vue
@@ -30,6 +30,9 @@
             New Editor
           </button>
         </div>
+        <p v-if="demoMessage" class="demo-message" data-testid="demo-status-message">
+          {{ demoMessage }}
+        </p>
       </template>
       <div v-else>
         <editor-creator-inline :visible="showCreator" @close="showCreator = !showCreator">
@@ -40,16 +43,69 @@
 </template>
 
 <script setup lang="ts">
-import { ref, inject, computed } from 'vue'
+import { ref, inject, computed, watch, onUnmounted } from 'vue'
 import trilogyIcon from '../static/trilogy.png'
 import EditorCreatorInline from '../components/editor/EditorCreatorInline.vue'
 import type { ConnectionStoreType } from '../stores/connectionStore'
 import { getDefaultValueFromHash, URL_HASH_KEYS } from '../stores/urlStore'
 const connectionStore = inject<ConnectionStoreType>('connectionStore')
+
+const props = defineProps({
+  // Set by the parent view when the demo launch fails; stops the spinner and
+  // is shown so a failure never reads as an endless load.
+  demoError: {
+    type: String,
+    default: '',
+  },
+})
+
+const DEMO_LOADING_TIMEOUT_MS = 30000
+const demoLoading = ref(false)
+const demoTimedOut = ref(false)
+const showCreator = ref(false)
+let demoTimer: ReturnType<typeof setTimeout> | null = null
+
+// Every loading state is bounded: if the launch hasn't landed us in the demo
+// editor by the deadline, give the button back so the user can retry instead
+// of watching a spinner forever.
+const beginDemoLoading = () => {
+  demoLoading.value = true
+  demoTimedOut.value = false
+  if (demoTimer) clearTimeout(demoTimer)
+  demoTimer = setTimeout(() => {
+    demoLoading.value = false
+    demoTimedOut.value = true
+  }, DEMO_LOADING_TIMEOUT_MS)
+}
+
 // The #demo=true deep link auto-launches the demo from the IDE shell; show
 // the loading state right away so this page reads as a splash, not a stop.
-const demoLoading = ref(getDefaultValueFromHash(URL_HASH_KEYS.DEMO, '') === 'true')
-const showCreator = ref(false)
+if (getDefaultValueFromHash(URL_HASH_KEYS.DEMO, '') === 'true') {
+  beginDemoLoading()
+}
+
+watch(
+  () => props.demoError,
+  (error) => {
+    if (error) {
+      demoLoading.value = false
+      if (demoTimer) clearTimeout(demoTimer)
+    }
+  },
+)
+
+onUnmounted(() => {
+  if (demoTimer) clearTimeout(demoTimer)
+})
+
+const demoMessage = computed(() => {
+  if (props.demoError) return `Demo setup failed: ${props.demoError}`
+  if (demoTimedOut.value && !demoLoading.value)
+    return 'Demo setup is taking longer than expected. Tap Demo Editor to retry.'
+  if (demoLoading.value) return 'Setting up the demo environment…'
+  return ''
+})
+
 const emit = defineEmits([
   'demo-started',
   'sidebar-screen-selected',
@@ -57,12 +113,8 @@ const emit = defineEmits([
   'documentation-key-selected',
 ])
 const startDemo = () => {
-  demoLoading.value = true
-
+  beginDemoLoading()
   emit('demo-started')
-  setTimeout(() => {
-    demoLoading.value = false
-  }, 30000)
 }
 
 const hasConnections = computed(() => {
@@ -198,6 +250,12 @@ h1 {
 
 .btn-tertiary:hover {
   background-color: #545b62;
+}
+
+.demo-message {
+  margin-top: 16px;
+  font-size: 14px;
+  color: var(--text-faint, #6c757d);
 }
 
 .spinner {

--- a/pyserver/io_models.py
+++ b/pyserver/io_models.py
@@ -9,6 +9,7 @@ from trilogy.authoring import (
     NumericType,
     TraitDataType,
     MapType,
+    ValidatedType,
 )  # , NumericType, TraitDataType
 from pydantic import BaseModel, Field
 
@@ -41,6 +42,7 @@ class UIConcept(BaseModel):
         | NumericType
         | TraitDataType
         | EnumType
+        | ValidatedType
     )
     purpose: Purpose
     description: Optional[str] = None
@@ -167,6 +169,7 @@ class QueryOutColumn(BaseModel):
         | MapType
         | NumericType
         | EnumType
+        | ValidatedType
     )
     purpose: Purpose
     traits: List[str] | None = None

--- a/pyserver/mcp_server.py
+++ b/pyserver/mcp_server.py
@@ -12,6 +12,7 @@ from trilogy.core.models.core import (
     DataTyped,
     StructComponent,
     EnumType,
+    ValidatedType,
 )
 import httpx
 from trilogy.core.models.environment import DictImportResolver, EnvironmentConfig
@@ -103,6 +104,7 @@ def datatype_to_str_datatype(
         | DataTyped
         | StructComponent
         | EnumType
+        | ValidatedType
     ),
 ) -> str:
     """Convert a TraitDataType to a string representation"""
@@ -127,6 +129,8 @@ def datatype_to_str_datatype(
         return f"{datatype.name}:{datatype_to_str_datatype(datatype.type)}>"
     elif isinstance(datatype, EnumType):
         return f"ENUM<{datatype_to_str_datatype(datatype.data_type)}[{','.join(datatype.values)}]>"
+    elif isinstance(datatype, ValidatedType):
+        return str(datatype)
     return str(datatype.name)
 
 


### PR DESCRIPTION
## Problem

On iPhone, `https://trilogydata.dev/trilogy-studio-core/#demo=true` showed a near-white screen with an endless spinner after the initial load. Not reproducible in responsive mode because it requires an **already-loaded document**:

Navigating to `#demo=true` when the app is already running (Safari restoring the tab, tapping the link twice, entering the URL in an open tab) is a *same-document navigation*:

1. `mounted` — the only place the demo deep link was handled — never re-runs.
2. The `hashchange` listener in `useScreenNavigation` sees no `screen` key and resets to the welcome screen; the `demo` key is ignored.
3. `WelcomePage` initializes `demoLoading = true` from the hash with no timeout → eternal spinner on a mostly-blank page, zero console output.

Reproduced against prod with Playwright WebKit iPhone emulation.

## Fixes

- **IDE + MobileIDE**: listen for `hashchange` and (re)launch the demo whenever `#demo=true` appears, with a single-flight guard. Initial-load path unchanged, now routed through the same guarded launcher.
- **MobileIDE**: wait for store hydration before demo setup (parity with desktop IDE) — closes a race where hydration could clobber the freshly-created demo connection on slow devices.
- **Error surfacing**: demo launch failures are caught and shown on the welcome page instead of dying as unhandled rejections behind a spinner.
- **WelcomePage**: every demo loading state is bounded by a 30s timeout that restores the retry button; status/error text shown under the buttons.

## Verification

- `vue-tsc` clean; 1051 unit tests pass.
- Playwright `test-trilogy-editor` spec (incl. `test_demo_deep_link`, `test_demo_editor`) passes on chromium + Mobile Safari against the production build.
- WebKit iPhone-13 emulation against local preview: fresh cold load, same-document navigation (the stranding case), and cold reload with persisted state all land in the demo editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)