### PR TITLE
[Chore] Bump studio version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trilogy-studio-app",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",


### PR DESCRIPTION
The local serve fixes in #241/#242 landed on `main` without a version bump, so `check-studio-version` saw `v0.1.0` already released and skipped `release-studio`. The site deploy ran; only the GitHub release/tag was skipped.

Bumping to `0.1.1` republishes the bundle `trilogy serve` pulls from `/releases/latest/download/`.

`CONTRACT_VERSION` stays at 1 — nothing in those commits changed the remote store contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)