### PR TITLE
[Feat] Render Trilogy chart statements in the studio

### DIFF
--- a/e2e/test-trilogy-editor.spec.ts
+++ b/e2e/test-trilogy-editor.spec.ts
@@ -22,6 +22,12 @@ test.beforeEach(async ({ page }) => {
  * resolves to a cursor move rather than select-all, hence the triple click.
  */
 async function selectAllEditorContent(page: Page, browser: Browser) {
+  // Mobile stacks the editor and the results into tabs and flips to results
+  // when a query starts, so the editor is off-screen after the first run.
+  const editorTab = page.getByTestId('editor-tab')
+  if (await editorTab.isVisible().catch(() => false)) {
+    await editorTab.click()
+  }
   const editor = page.getByTestId('editor')
   await editor.click()
   if (browser.browserType().name() === 'webkit') {

--- a/e2e/test-trilogy-editor.spec.ts
+++ b/e2e/test-trilogy-editor.spec.ts
@@ -1,3 +1,4 @@
+import type { Browser, Page } from '@playwright/test'
 import { test, expect } from './console-capture'
 import {
   drillMobileTree,
@@ -14,6 +15,21 @@ const connectionName = 'duckdb-test2'
 test.beforeEach(async ({ page }) => {
   await prepareTestPage(page)
 })
+
+/**
+ * Focus the main editor and select everything in it, so the next keystrokes
+ * replace the content. Webkit runs a macOS monaco where `ControlOrMeta+a`
+ * resolves to a cursor move rather than select-all, hence the triple click.
+ */
+async function selectAllEditorContent(page: Page, browser: Browser) {
+  const editor = page.getByTestId('editor')
+  await editor.click()
+  if (browser.browserType().name() === 'webkit') {
+    await editor.click({ clickCount: 3 })
+  } else {
+    await editor.press('ControlOrMeta+a')
+  }
+}
 
 test('test', async ({ page, isMobile, browser }) => {
   await page.goto('#skipTips=true')
@@ -40,13 +56,7 @@ test('test', async ({ page, isMobile, browser }) => {
     await drillMobileTree(page, ['Browser Storage', connectionName])
   }
   await page.getByTestId(`editor-e-local-${localConnectionId(connectionName)}-test-one`).click()
-  const editor = page.getByTestId('editor')
-  await editor.click()
-  if (browser.browserType().name() === 'webkit') {
-    await page.getByTestId('editor').click({ clickCount: 3 })
-  } else {
-    await page.getByTestId('editor').press('ControlOrMeta+a')
-  }
+  await selectAllEditorContent(page, browser)
 
   const testOneContent = `
 auto x <- [1,2,3,4,5];
@@ -57,6 +67,23 @@ select unnest(x) as rows;
   await page.keyboard.type(testOneContent)
 
   await runEditorQueryAndExpectCount(page, 5)
+
+  // A `chart ...` statement is an explicit request for a visualization: the
+  // editor runs the layer's query AND lands on the rendered chart rather than
+  // leaving the author on the result grid.
+  await selectAllEditorContent(page, browser)
+  await page.keyboard.type(`
+auto vals <- [1,2,3,4,5];
+auto rows <- unnest(vals);
+auto doubled <- rows * 2;
+
+chart layer bar (x_axis <- rows, y_axis <- doubled);
+`)
+
+  // The layer's rows are there behind the chart...
+  await runEditorQueryAndExpectCount(page, 5)
+  // ...and the pane opened on the chart the statement declared.
+  await expect(page.locator('.vega-active canvas').first()).toBeVisible({ timeout: 30000 })
 })
 
 test('test_demo_deep_link', async ({ page }) => {

--- a/lib/components/editor/Editor.vue
+++ b/lib/components/editor/Editor.vue
@@ -639,21 +639,28 @@ export default defineComponent({
             editor.generated_sql = result.generatedSql
           }
           if (result.results) {
-            // check if the result headers have changed
-            // and clear our cached chart config if so. Skip when prior
-            // results are the empty rehydrated placeholder — comparing
-            // against it would wipe a persisted chart config on first run.
-            if (
-              this.editorData.results &&
-              this.editorData.results.headers &&
-              this.editorData.results.headers.size > 0
-            ) {
-              let identical =
-                JSON.stringify(Array.from(this.editorData.results.headers.keys())) ==
-                JSON.stringify(Array.from(result.results.headers.keys()))
-              // changed is if the map keys are different
-              if (!identical) {
-                this.editorData.setChartConfig(null)
+            // A `chart ...` statement declares its own chart; that wins over
+            // both the cached config and the header-change reset below.
+            if (result.chartConfig) {
+              editor.setStatementChartConfig(result.chartConfig, result.chartWarnings || [])
+            } else {
+              editor.clearStatementChart()
+              // check if the result headers have changed
+              // and clear our cached chart config if so. Skip when prior
+              // results are the empty rehydrated placeholder — comparing
+              // against it would wipe a persisted chart config on first run.
+              if (
+                this.editorData.results &&
+                this.editorData.results.headers &&
+                this.editorData.results.headers.size > 0
+              ) {
+                let identical =
+                  JSON.stringify(Array.from(this.editorData.results.headers.keys())) ==
+                  JSON.stringify(Array.from(result.results.headers.keys()))
+                // changed is if the map keys are different
+                if (!identical) {
+                  this.editorData.setChartConfig(null)
+                }
               }
             }
             this.editorStore.setEditorResults(id, result.results)

--- a/lib/components/editor/ResultComponent.vue
+++ b/lib/components/editor/ResultComponent.vue
@@ -26,6 +26,8 @@
         :containerHeight="containerHeight"
         :type="editorData.type"
         :chartConfig="editorData.chartConfig"
+        :chartFromStatement="editorData.chartFromStatement"
+        :chartWarnings="editorData.chartStatementWarnings"
         :error="editorData.error || undefined"
         :symbols="editorData.completionSymbols"
         @config-change="(config: ChartConfig) => editorData.setChartConfig(config)"

--- a/lib/components/editor/Results.vue
+++ b/lib/components/editor/Results.vue
@@ -61,6 +61,10 @@
       />
 
       <div v-else-if="displayTab === 'visualize'" class="sql-view">
+        <div v-if="chartWarnings && chartWarnings.length" class="chart-statement-warnings">
+          <i class="mdi mdi-alert-circle-outline" aria-hidden="true"></i>
+          <span v-for="warning in chartWarnings" :key="warning">{{ warning }}</span>
+        </div>
         <vega-lite-chart
           :data="results.data"
           :columns="results.headers"
@@ -147,6 +151,16 @@ export default {
       type: Object as PropType<ChartConfig | null>,
       required: false,
     },
+    /** The chart config came from a Trilogy `chart ...` statement, so the
+     *  author asked for a chart -- open on it rather than the result grid. */
+    chartFromStatement: {
+      type: Boolean,
+      default: false,
+    },
+    chartWarnings: {
+      type: Array as PropType<string[]>,
+      required: false,
+    },
     error: {
       type: String,
       required: false,
@@ -169,10 +183,21 @@ export default {
     },
   },
   emits: ['config-change', 'drilldown-click', 'refresh-click'],
+  watch: {
+    // Running a chart statement is an explicit request for a chart, so land on
+    // it. Only on the transition into that state -- re-running the same chart
+    // leaves whichever tab the user has since chosen alone.
+    chartFromStatement(isStatementChart: boolean) {
+      if (isStatementChart) {
+        this.switchToVisualizeTab()
+      }
+    },
+  },
   data() {
     return {
-      activeTab:
-        this.defaultTab || getDefaultValueFromHash(URL_HASH_KEYS.ACTIVE_EDITOR_TAB, 'results'),
+      activeTab: this.chartFromStatement
+        ? 'visualize'
+        : this.defaultTab || getDefaultValueFromHash(URL_HASH_KEYS.ACTIVE_EDITOR_TAB, 'results'),
       activeDrilldown: null as Drilldown | null,
       TABS_HEIGHT: 26,
     }
@@ -264,6 +289,17 @@ export default {
 </script>
 
 <style scoped>
+.chart-statement-warnings {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  padding: 4px 8px;
+  font-size: 12px;
+  color: var(--text-faint, #888);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
 .results-container {
   display: flex;
   flex-direction: column;

--- a/lib/editors/chartStatement.test.ts
+++ b/lib/editors/chartStatement.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import { chartStatementToConfig, type ChartStatementSpec } from './chartStatement'
+import { ColumnType, type ResultColumn, type Row } from './results'
+import { generateVegaSpec } from '../dashboards/spec'
+import { ChromaChartHelpers } from '../components/chartHelpers'
+
+function spec(overrides: Partial<ChartStatementSpec> = {}): ChartStatementSpec {
+  return {
+    layers: [
+      {
+        chart_type: 'bar',
+        generated_sql: 'select 1',
+        x_fields: ['category'],
+        y_fields: ['total_value'],
+        field_labels: { total_value: 'Total Value' },
+      },
+    ],
+    placements: [],
+    hide_legend: false,
+    show_title: false,
+    ...overrides,
+  }
+}
+
+describe('chartStatementToConfig', () => {
+  it('maps a single layer onto a chart config', () => {
+    const resolved = chartStatementToConfig(spec())
+
+    expect(resolved?.config).toEqual({
+      chartType: 'bar',
+      xField: 'category',
+      yField: 'total_value',
+    })
+    expect(resolved?.warnings).toEqual([])
+  })
+
+  it('translates trilogy role names to studio field names', () => {
+    const resolved = chartStatementToConfig(
+      spec({
+        layers: [
+          {
+            chart_type: 'line',
+            x_fields: ['order_date'],
+            y_fields: ['revenue'],
+            color_field: 'region',
+            size_field: 'orders',
+            group_field: 'channel',
+            x_trellis_field: 'quarter',
+            y_trellis_field: 'segment',
+            annotation_field: 'note',
+          },
+        ],
+        hide_legend: true,
+        show_title: true,
+        scale_x: 'linear',
+        scale_y: 'log',
+      }),
+    )
+
+    expect(resolved?.config).toEqual({
+      chartType: 'line',
+      xField: 'order_date',
+      yField: 'revenue',
+      colorField: 'region',
+      sizeField: 'orders',
+      groupField: 'channel',
+      trellisField: 'quarter',
+      trellisRowField: 'segment',
+      annotationField: 'note',
+      hideLegend: true,
+      showTitle: true,
+      scaleX: 'linear',
+      scaleY: 'log',
+    })
+  })
+
+  it('renders a layer that binds the geo role as a map', () => {
+    // `geo` is a role, not a chart type, in Trilogy — binding it is the only
+    // way to ask for a map, so it decides the studio chart type.
+    const resolved = chartStatementToConfig(
+      spec({
+        layers: [{ chart_type: 'point', geo_field: 'state', color_field: 'revenue' }],
+      }),
+    )
+
+    expect(resolved?.config.chartType).toBe('geo-map')
+    expect(resolved?.config.geoField).toBe('state')
+  })
+
+  it('warns that only the first of several layers is rendered', () => {
+    const resolved = chartStatementToConfig(
+      spec({
+        layers: [
+          { chart_type: 'bar', x_fields: ['category'], y_fields: ['total'] },
+          { chart_type: 'line', x_fields: ['category'], y_fields: ['average'] },
+        ],
+      }),
+    )
+
+    expect(resolved?.config.chartType).toBe('bar')
+    expect(resolved?.warnings).toHaveLength(1)
+    expect(resolved?.warnings[0]).toContain('line')
+  })
+
+  it('warns about reference lines it cannot draw', () => {
+    const resolved = chartStatementToConfig(
+      spec({ placements: [{ kind: 'hline', value: 5, label: 'target' }] }),
+    )
+
+    expect(resolved?.warnings[0]).toContain('hline')
+  })
+
+  it('falls back to a bar chart for an unrecognized chart type', () => {
+    const resolved = chartStatementToConfig(
+      spec({ layers: [{ chart_type: 'sunburst', x_fields: ['category'], y_fields: ['total'] }] }),
+    )
+
+    expect(resolved?.config.chartType).toBe('bar')
+    expect(resolved?.warnings[0]).toContain('sunburst')
+  })
+
+  it('ignores an invalid scale rather than passing it through', () => {
+    const resolved = chartStatementToConfig(spec({ scale_y: 'exponential' }))
+
+    expect(resolved?.config.scaleY).toBeUndefined()
+  })
+
+  it('returns null when there is nothing to chart', () => {
+    expect(chartStatementToConfig(null)).toBeNull()
+    expect(chartStatementToConfig(undefined)).toBeNull()
+    expect(chartStatementToConfig({ layers: [] })).toBeNull()
+  })
+})
+
+describe('a chart statement config rendered by the studio chart pipeline', () => {
+  const columns = new Map<string, ResultColumn>([
+    ['category', { name: 'category', type: ColumnType.STRING }],
+    ['total_value', { name: 'total_value', type: ColumnType.NUMBER }],
+  ])
+  const data: Row[] = [
+    { category: 'a', total_value: 10 } as Row,
+    { category: 'b', total_value: 20 } as Row,
+  ]
+
+  it('survives field validation and encodes the roles the author bound', () => {
+    const resolved = chartStatementToConfig({
+      layers: [
+        {
+          chart_type: 'bar',
+          x_fields: ['category'],
+          y_fields: ['total_value'],
+        },
+      ],
+    })
+    if (!resolved) throw new Error('expected a chart config')
+
+    // A config the controls would reject gets thrown away and replaced by
+    // defaults, which would silently ignore what the statement asked for.
+    const helpers = new ChromaChartHelpers()
+    expect(helpers.validateConfigFields({ ...resolved.config }, columns)).toBe(true)
+
+    const spec: any = generateVegaSpec(data, resolved.config, columns, null)
+    expect(spec.encoding.x.field).toBe('category')
+    expect(spec.encoding.y.field).toBe('total_value')
+  })
+})

--- a/lib/editors/chartStatement.test.ts
+++ b/lib/editors/chartStatement.test.ts
@@ -156,7 +156,12 @@ describe('a chart statement config rendered by the studio chart pipeline', () =>
 
     // A config the controls would reject gets thrown away and replaced by
     // defaults, which would silently ignore what the statement asked for.
-    const helpers = new ChromaChartHelpers()
+    const helpers = new ChromaChartHelpers({
+      onDimensionClick: () => {},
+      onPointClick: () => {},
+      onBackgroundClick: () => {},
+      onDrilldownClick: () => {},
+    })
     expect(helpers.validateConfigFields({ ...resolved.config }, columns)).toBe(true)
 
     const spec: any = generateVegaSpec(data, resolved.config, columns, null)

--- a/lib/editors/chartStatement.ts
+++ b/lib/editors/chartStatement.ts
@@ -1,0 +1,159 @@
+/**
+ * Trilogy `chart ...` statements, translated into the studio's ChartConfig.
+ *
+ * A chart statement looks like
+ *
+ *   chart layer bar (x_axis <- category, y_axis <- sum(value) as total)
+ *     set hide_legend
+ *     order by total desc limit 10;
+ *
+ * The resolver compiles each layer to its own SELECT and hands back the role
+ * bindings alongside; this module turns that into the same ChartConfig the
+ * chart controls produce, so a statement-authored chart and a hand-configured
+ * one render through exactly one path.
+ *
+ * Role names on the wire are pytrilogy's (`x_trellis`, `y_trellis`), not the
+ * studio's (`trellisField`, `trellisRowField`) -- the wire format stays a
+ * faithful projection of the language and the translation lives here.
+ */
+import type { ChartConfig, chartTypes } from './results'
+
+export interface ChartStatementPlacement {
+  kind: string
+  value?: string | number | boolean | null
+  label?: string | null
+}
+
+export interface ChartStatementLayer {
+  chart_type: string
+  generated_sql?: string | null
+  parameters?: Record<string, string | number | (string | number)[]> | null
+  x_fields?: string[]
+  y_fields?: string[]
+  color_field?: string | null
+  size_field?: string | null
+  group_field?: string | null
+  x_trellis_field?: string | null
+  y_trellis_field?: string | null
+  geo_field?: string | null
+  annotation_field?: string | null
+  field_labels?: Record<string, string>
+}
+
+export interface ChartStatementSpec {
+  layers: ChartStatementLayer[]
+  placements?: ChartStatementPlacement[]
+  hide_legend?: boolean
+  show_title?: boolean
+  scale_x?: string | null
+  scale_y?: string | null
+}
+
+export interface ChartStatementResolution {
+  config: ChartConfig
+  /** Parts of the statement the studio can't render, in author-facing terms. */
+  warnings: string[]
+}
+
+/** Trilogy's CHART_TYPE terminal. Every member is also a studio chart type,
+ *  so the type name passes through untranslated. The studio's `tree`,
+ *  `beeswarm` and `geo-map` have no statement spelling. */
+const TRILOGY_CHART_TYPES: chartTypes[] = [
+  'line',
+  'bar',
+  'barh',
+  'point',
+  'area',
+  'headline',
+  'donut',
+  'heatmap',
+  'boxplot',
+  'treemap',
+]
+
+const SCALE_TYPES = ['linear', 'log', 'sqrt'] as const
+type ScaleType = (typeof SCALE_TYPES)[number]
+
+function asScale(value: string | null | undefined): ScaleType | undefined {
+  return SCALE_TYPES.includes(value as ScaleType) ? (value as ScaleType) : undefined
+}
+
+/**
+ * Build a ChartConfig from a resolved chart statement, or null if the spec
+ * carries no layer to render.
+ *
+ * Only the first layer becomes the config: the studio renders one dataset per
+ * chart, while a statement may layer several independent selects. Extra layers
+ * are reported in `warnings` rather than dropped silently.
+ */
+export function chartStatementToConfig(
+  spec: ChartStatementSpec | null | undefined,
+): ChartStatementResolution | null {
+  const layer = spec?.layers?.[0]
+  if (!spec || !layer) {
+    return null
+  }
+  const warnings: string[] = []
+
+  if (spec.layers.length > 1) {
+    const extra = spec.layers
+      .slice(1)
+      .map((l) => l.chart_type)
+      .join(', ')
+    warnings.push(
+      `Only the first layer (${layer.chart_type}) is rendered; ` +
+        `the studio charts a single result set, so the ${extra} layer(s) were skipped.`,
+    )
+  }
+  if (spec.placements?.length) {
+    warnings.push(
+      `Reference lines (${spec.placements
+        .map((p) => p.kind)
+        .join(', ')}) aren't supported by studio charts yet.`,
+    )
+  }
+
+  const xFields = layer.x_fields ?? []
+  const yFields = layer.y_fields ?? []
+
+  // `geo` has no chart type of its own in the language -- the role is what
+  // makes a chart a map -- so a layer that binds it renders as the studio's
+  // geo-map regardless of the declared layer type.
+  let chartType: chartTypes
+  if (layer.geo_field) {
+    chartType = 'geo-map'
+  } else if (TRILOGY_CHART_TYPES.includes(layer.chart_type as chartTypes)) {
+    chartType = layer.chart_type as chartTypes
+  } else {
+    chartType = 'bar'
+    warnings.push(`Unknown chart type '${layer.chart_type}'; rendering as a bar chart.`)
+  }
+
+  const config: ChartConfig = {
+    chartType,
+    xField: xFields[0] || undefined,
+    yField: yFields[0] || undefined,
+    yField2: yFields[1] || undefined,
+    colorField: layer.color_field || undefined,
+    sizeField: layer.size_field || undefined,
+    groupField: layer.group_field || undefined,
+    trellisField: layer.x_trellis_field || undefined,
+    trellisRowField: layer.y_trellis_field || undefined,
+    geoField: layer.geo_field || undefined,
+    annotationField: layer.annotation_field || undefined,
+    hideLegend: spec.hide_legend || undefined,
+    showTitle: spec.show_title || undefined,
+    scaleX: asScale(spec.scale_x),
+    scaleY: asScale(spec.scale_y),
+  }
+
+  // Drop the undefined keys so a persisted config stays comparable with one
+  // the controls produced, and so JSON round-trips don't grow null noise.
+  for (const key of Object.keys(config) as (keyof ChartConfig)[]) {
+    if (config[key] === undefined) {
+      delete config[key]
+    }
+  }
+
+  return { config, warnings }
+}

--- a/lib/editors/editor.ts
+++ b/lib/editors/editor.ts
@@ -111,6 +111,12 @@ export default class Editor implements EditorInterface {
   changed: boolean
   deleted: boolean
   chartConfig?: ChartConfig | null
+  /** True when `chartConfig` came from a Trilogy `chart ...` statement rather
+   *  than the chart controls. In-memory only: it describes the last run, so it
+   *  is recomputed on execution rather than restored from storage. */
+  chartFromStatement: boolean
+  /** Parts of that chart statement the studio can't render. */
+  chartStatementWarnings: string[]
   completionSymbols: CompletionItem[]
   refinementSession?: EditorRefinementSession | null
   scrollPosition?: { line: number; column: number } | null
@@ -182,6 +188,8 @@ export default class Editor implements EditorInterface {
     // default to change for save
     this.changed = true
     this.deleted = false
+    this.chartFromStatement = false
+    this.chartStatementWarnings = []
     this.completionSymbols = []
     this.remoteStoreId = remoteStoreId
     this.remotePath =
@@ -259,7 +267,28 @@ export default class Editor implements EditorInterface {
 
   setChartConfig(chartConfig: ChartConfig | null) {
     this.chartConfig = chartConfig
+    this.chartFromStatement = false
+    this.chartStatementWarnings = []
     this.changed = true
+  }
+
+  /**
+   * Adopt the chart a `chart ...` statement declared. Kept distinct from
+   * `setChartConfig` so the results pane can tell an authored chart (which
+   * should be shown straight away) from one the user built with the controls.
+   */
+  setStatementChartConfig(chartConfig: ChartConfig, warnings: string[] = []) {
+    this.chartConfig = chartConfig
+    this.chartFromStatement = true
+    this.chartStatementWarnings = warnings
+    this.changed = true
+  }
+
+  /** Called when a run produced no chart statement, so a stale authored chart
+   *  doesn't keep hijacking the results pane. */
+  clearStatementChart() {
+    this.chartFromStatement = false
+    this.chartStatementWarnings = []
   }
 
   /**

--- a/lib/monaco/trilogyLanguage.test.ts
+++ b/lib/monaco/trilogyLanguage.test.ts
@@ -178,6 +178,19 @@ describe('trilogy monarch grammar', () => {
     expect(typeOf('order by x desc nulls last;', 'nulls last')).toBe('keyword')
   })
 
+  it('tokenizes chart statement clauses', () => {
+    const chart =
+      'chart set scale_y: log layer bar (x_axis <- category, y_axis <- total) place hline at 5;'
+    expect(typeOf(chart, 'layer bar')).toBe('keyword')
+    expect(typeOf(chart, 'set scale_y: log')).toBe('keyword')
+    expect(typeOf(chart, 'place hline at')).toBe('keyword')
+    // Roles are keywords only where a binding arrow follows them; the
+    // binding-lhs `property` rule would otherwise claim them.
+    expect(typeOf(chart, 'x_axis')).toBe('keyword')
+    expect(typeOf(chart, 'y_axis')).toBe('keyword')
+    expect(typeOf('select x_axis;', 'x_axis')).not.toBe('keyword')
+  })
+
   it('has no duplicate entries in any word list', () => {
     for (const name of ['keywords', 'functions', 'typeKeywords', 'definitions'] as const) {
       const list = (trilogyMonarchLanguage as unknown as Record<string, string[]>)[name]

--- a/lib/stores/queryExecutionService.test.ts
+++ b/lib/stores/queryExecutionService.test.ts
@@ -115,6 +115,83 @@ describe('QueryExecutionService', () => {
     expect(result.results?.data).toEqual([{ value: 1 }])
   })
 
+  it('surfaces the chart a `chart ...` statement declared', async () => {
+    const resolver = {
+      resolve_query: vi.fn(async () => ({
+        data: {
+          generated_sql: 'select category, sum(value) as total_value from facts group by 1',
+          columns: [
+            { name: 'category', purpose: 'property' },
+            { name: 'total_value', purpose: 'metric' },
+          ],
+          generated_output: null,
+          select_count: 1,
+          chart: {
+            layers: [
+              {
+                chart_type: 'bar',
+                generated_sql: 'select category, sum(value) as total_value from facts group by 1',
+                x_fields: ['category'],
+                y_fields: ['total_value'],
+              },
+            ],
+            placements: [{ kind: 'hline', value: 5, label: 'target' }],
+            hide_legend: true,
+          },
+        },
+      })),
+    } as any
+    const { provider, executeSql } = makeProvider({ connected: true })
+    const service = new QueryExecutionService(resolver, provider, false)
+
+    const { resultPromise } = await service.executeQuery('worker-duckdb', {
+      text: 'chart layer bar (x_axis <- category, y_axis <- sum(value) as total_value);',
+      editorType: 'trilogy',
+      imports: [],
+    })
+
+    const result = await resultPromise
+
+    // The first layer's SQL is what actually runs, so the chart renders over
+    // the same rows the results grid shows.
+    expect(executeSql).toHaveBeenCalledWith(
+      'select category, sum(value) as total_value from facts group by 1',
+      null,
+    )
+    expect(result.chartConfig).toEqual({
+      chartType: 'bar',
+      xField: 'category',
+      yField: 'total_value',
+      hideLegend: true,
+    })
+    expect(result.chartWarnings?.[0]).toContain('hline')
+  })
+
+  it('leaves the chart config unset for an ordinary select', async () => {
+    const resolver = {
+      resolve_query: vi.fn(async () => ({
+        data: {
+          generated_sql: 'select 1 as value',
+          columns: [{ name: 'value', purpose: 'metric' }],
+          generated_output: null,
+          select_count: 1,
+        },
+      })),
+    } as any
+    const { provider } = makeProvider({ connected: true })
+    const service = new QueryExecutionService(resolver, provider, false)
+
+    const { resultPromise } = await service.executeQuery('worker-duckdb', {
+      text: 'select value;',
+      editorType: 'trilogy',
+      imports: [],
+    })
+
+    const result = await resultPromise
+    expect(result.chartConfig).toBeUndefined()
+    expect(result.chartWarnings).toBeUndefined()
+  })
+
   it('calls failure callbacks when the connection id cannot be resolved', async () => {
     const resolver = {
       resolve_query: vi.fn(),

--- a/lib/stores/queryExecutionService.ts
+++ b/lib/stores/queryExecutionService.ts
@@ -1,4 +1,6 @@
 import { Results, type ResultColumn, ColumnType } from '../editors/results'
+import type { ChartConfig } from '../editors/results'
+import { chartStatementToConfig } from '../editors/chartStatement'
 import type { EditorType } from '../editors/editor'
 import { isTrilogyType } from '../editors/fileTypes'
 import type { ContentInput } from '../stores/resolver'
@@ -40,6 +42,11 @@ export interface QueryResult {
   resultSize: number
   columnCount: number
   selectCount?: number
+  /** Set when the query was a Trilogy `chart ...` statement: the chart the
+   *  author declared, already translated into studio chart config. */
+  chartConfig?: ChartConfig
+  /** Parts of that chart statement the studio can't render. */
+  chartWarnings?: string[]
 }
 
 export interface BatchQueryResult {
@@ -566,13 +573,18 @@ export default class QueryExecutionService {
               }
 
               // Add to results
-              let resultObj = {
+              const chartResolution = chartStatementToConfig(queryResult.chart)
+              let resultObj: QueryResult = {
                 success: true,
                 generatedSql: queryResult.generated_sql,
                 results: sqlResponse,
                 resultSize: sqlResponse.data.length,
                 columnCount: sqlResponse.headers.size,
                 executionTime: new Date().getTime() - startTime,
+                chartConfig: chartResolution?.config,
+                chartWarnings: chartResolution?.warnings.length
+                  ? chartResolution.warnings
+                  : undefined,
               }
 
               if (onSuccess && queryResult.label && onSuccess[queryResult.label]) {
@@ -1230,6 +1242,10 @@ export default class QueryExecutionService {
 
       generatedSql = resolveResponse.data.generated_sql
 
+      // A `chart ...` statement carries its own rendering intent; translate it
+      // once here so every caller gets the config alongside the rows.
+      const chartResolution = chartStatementToConfig(resolveResponse.data.chart)
+
       const headers = resolveResponse.data.columns
 
       // Second step: Execute query — merge SQL-binding parameters from the resolver
@@ -1270,18 +1286,7 @@ export default class QueryExecutionService {
         })
       }
       const selectCount = resolveResponse?.data.select_count
-      if (onSuccess) {
-        onSuccess({
-          success: true,
-          generatedSql,
-          results: sqlResponse,
-          executionTime: new Date().getTime() - startTime,
-          resultSize,
-          columnCount,
-          selectCount,
-        })
-      }
-      return {
+      const successResult: QueryResult = {
         success: true,
         generatedSql,
         results: sqlResponse,
@@ -1289,7 +1294,13 @@ export default class QueryExecutionService {
         resultSize,
         columnCount,
         selectCount,
+        chartConfig: chartResolution?.config,
+        chartWarnings: chartResolution?.warnings.length ? chartResolution.warnings : undefined,
       }
+      if (onSuccess) {
+        onSuccess(successResult)
+      }
+      return successResult
     } catch (error) {
       // Diagnostic: log the raw thrown value so non-Error, non-string
       // throws don't get hidden behind 'Unknown error occurred'. Remove

--- a/lib/stores/resolver.ts
+++ b/lib/stores/resolver.ts
@@ -1,4 +1,5 @@
 import { ModelConfig } from '../models'
+import type { ChartStatementSpec } from '../editors/chartStatement'
 
 import { type UserSettingsStoreType } from './userSettingsStore'
 
@@ -77,6 +78,9 @@ export interface QueryAtom {
   label?: string
   select_count?: number
   parameters?: Record<string, string | number | (string | number)[]> | null
+  /** Present when the statement was a `chart ...`; `generated_sql` is then
+   *  the first layer's query, so chart-unaware callers still get rows. */
+  chart?: ChartStatementSpec | null
 }
 
 export interface QueryResponse {

--- a/prism-trilogy/README.md
+++ b/prism-trilogy/README.md
@@ -99,7 +99,7 @@ Two ordering decisions in the grammar are load-bearing:
 ## Keeping up with the language
 
 `src/vocabulary.ts` is derived from `trilogy/parsing/trilogy.lark` in
-[pytrilogy](https://pypi.org/project/pytrilogy/), cut against **0.3.307**.
+[pytrilogy](https://pypi.org/project/pytrilogy/), cut against **0.3.335**.
 
 ## Development
 

--- a/prism-trilogy/package.json
+++ b/prism-trilogy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trilogy-data/prism-trilogy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Prism syntax highlighting for the Trilogy language, plus the raw language vocabulary.",
   "private": false,
   "publishConfig": {

--- a/prism-trilogy/src/grammar.test.ts
+++ b/prism-trilogy/src/grammar.test.ts
@@ -194,6 +194,26 @@ describe('keywords', () => {
     expect(typeOf('select bar -> b;', 'bar')).not.toBe('keyword')
   })
 
+  it('tokenizes chart layer roles, but only as bindings', () => {
+    const layer = 'chart layer bar (x_axis <- category, y_axis <- total);'
+    expect(typeOf(layer, 'x_axis')).toBe('keyword')
+    expect(typeOf(layer, 'y_axis')).toBe('keyword')
+    expect(typeOf('chart layer bar (x_trellis <- quarter);', 'x_trellis')).toBe('keyword')
+    // A concept that happens to be called `x_axis` is still a plain name.
+    expect(typeOf('select x_axis;', 'x_axis')).not.toBe('keyword')
+  })
+
+  it('tokenizes chart settings, including the scale value', () => {
+    expect(typeOf('chart set hide_legend layer bar (x <- a);', 'set hide_legend')).toBe('keyword')
+    expect(typeOf('chart set scale_y: log layer bar (x <- a);', 'set scale_y: log')).toBe('keyword')
+    // `log` outside that clause is the math function, not a keyword.
+    expect(typeOf('select log(x) as y;', 'log')).toBe('function')
+  })
+
+  it('tokenizes chart placements', () => {
+    expect(typeOf('chart layer bar (x <- a) place hline at 5;', 'place hline at')).toBe('keyword')
+  })
+
   it('tokenizes infix like/ilike', () => {
     expect(typeOf(`where name like '%a%';`, 'like')).toBe('keyword')
     expect(typeOf(`where name not ilike '%a%';`, 'not ilike')).toBe('keyword')

--- a/prism-trilogy/src/vocabulary.ts
+++ b/prism-trilogy/src/vocabulary.ts
@@ -136,7 +136,16 @@ export const CONTEXTUAL_KEYWORD_PATTERNS = [
   // chart statement: the chart types are far too generic to match standalone
   String.raw`\blayer\s+(?:line|barh|bar|point|area|headline|donut|heatmap|boxplot|treemap)\b`,
   String.raw`\bplace\s+(?:hline|vline)\s+at\b`,
-  String.raw`\bset\s+(?:hide_legend|show_title|scale_x|scale_y)\b`,
+  String.raw`\bset\s+(?:hide_legend|show_title)\b`,
+  // `set scale_y: log` -- the scale value only reads as a keyword here, and
+  // `log` is a math function everywhere else, so it has to come along.
+  String.raw`\bset\s+(?:scale_x|scale_y)\b(?:\s*:\s*(?:linear|log|sqrt)\b)?`,
+  // Chart layer roles, gated on the binding arrow that must follow them. Only
+  // the roles no one would name a concept are here: `color`, `size`, `group`,
+  // `geo` and `annotation` are ordinary enough that matching them would light
+  // up the left-hand side of `auto color <- '#fff';`, which looks identical
+  // once the purpose word in front of it has been consumed.
+  String.raw`\b(?:x_axis|y_axis|x_trellis|y_trellis)\b(?=\s*<-)`,
 ] as const
 
 /** PURPOSE / PROPERTY / AUTO / parameter declarations -- what introduces a name. */

--- a/pyserver/io_models.py
+++ b/pyserver/io_models.py
@@ -175,6 +175,48 @@ class QueryOutColumn(BaseModel):
     keys: list[str] | None = None
 
 
+class ChartPlacementOut(BaseModel):
+    """A `place hline|vline at <literal> [as <label>]` reference line."""
+
+    kind: str
+    value: str | int | float | bool | None = None
+    label: str | None = None
+
+
+class ChartLayerOut(BaseModel):
+    """One `layer <type> (<role> <- <expr>, ...)` of a chart statement.
+
+    Roles keep pytrilogy's names (`x_trellis`, not the studio's
+    `trellisRowField`); the client owns the translation into its own
+    ChartConfig so this stays a faithful projection of
+    ``ProcessedChartLayer``.
+    """
+
+    chart_type: str
+    generated_sql: str | None = None
+    parameters: dict[str, str | int | float | list] | None = None
+    x_fields: list[str] = Field(default_factory=list)
+    y_fields: list[str] = Field(default_factory=list)
+    color_field: str | None = None
+    size_field: str | None = None
+    group_field: str | None = None
+    x_trellis_field: str | None = None
+    y_trellis_field: str | None = None
+    geo_field: str | None = None
+    annotation_field: str | None = None
+    # display labels for roles bound with `as`, keyed by the select output name
+    field_labels: dict[str, str] = Field(default_factory=dict)
+
+
+class ChartOut(BaseModel):
+    layers: list[ChartLayerOut] = Field(default_factory=list)
+    placements: list[ChartPlacementOut] = Field(default_factory=list)
+    hide_legend: bool = False
+    show_title: bool = False
+    scale_x: str | None = None
+    scale_y: str | None = None
+
+
 class QueryOut(BaseModel):
     generated_sql: str | None
     columns: list[QueryOutColumn] | None
@@ -183,6 +225,10 @@ class QueryOut(BaseModel):
     label: str | None = None
     select_count: int | None = None
     parameters: dict[str, str | int | float | list] | None = None
+    # Present only for `chart ...` statements. `generated_sql` above is the
+    # first layer's query, so a client that ignores this field still gets a
+    # runnable result set.
+    chart: ChartOut | None = None
 
 
 class MultiQueryOutSchema(BaseModel):

--- a/pyserver/pyproject.toml
+++ b/pyserver/pyproject.toml
@@ -7,7 +7,9 @@ requires-python = ">=3.10"
 authors = [{ name = "efromvt" }]
 license = { text = "MIT" }
 dependencies = [
-    "pytrilogy>=0.3.289",
+    # 0.3.335 is the floor for chart statements: ProcessedChartLayer only grew
+    # `field_labels` (the `as` display names) there, and query_helpers reads it.
+    "pytrilogy>=0.3.335",
     "anyio>=4.5",
     "click>=8.1.0",
     "httpx>=0.27",

--- a/pyserver/query_helpers.py
+++ b/pyserver/query_helpers.py
@@ -20,8 +20,11 @@ from trilogy.authoring import (
 from trilogy.constants import Parsing
 from trilogy.core.internal import DEFAULT_CONCEPTS
 from trilogy.core.models.core import ListWrapper, TraitDataType
+from trilogy.core.statements.author import ChartStatement
 from trilogy.core.statements.execute import (
     PROCESSED_STATEMENT_TYPES,
+    ProcessedChartLayer,
+    ProcessedChartStatement,
     ProcessedCopyStatement,
     ProcessedQuery,
     ProcessedQueryPersist,
@@ -43,6 +46,9 @@ from env_helpers import (
     resolve_import_path,
 )
 from io_models import (
+    ChartLayerOut,
+    ChartOut,
+    ChartPlacementOut,
     MultiQueryInSchema,
     QueryInSchema,
     QueryOut,
@@ -249,10 +255,15 @@ def generate_single_query(
     parse_time = time.time() - parse_start
     default_return: list[QueryOutColumn] = []
     default_values: list[dict] | None = None
+    # A chart statement counts once no matter how many layers it holds: it is
+    # one statement, and consumers use this to reject multi-select input.
     select_count = sum(
         1
         for s in parsed
-        if isinstance(s, (SelectStatement, MultiSelectStatement, PersistStatement))
+        if isinstance(
+            s,
+            (SelectStatement, MultiSelectStatement, PersistStatement, ChartStatement),
+        )
     )
     # Comments are parsed as statements; a query ending in (or consisting only
     # of) comments should return results from the last real statement rather
@@ -329,7 +340,10 @@ def generate_single_query(
             validate_results.as_dict() if validate_results else None,
             select_count,
         )
-    if not isinstance(final, (SelectStatement, MultiSelectStatement, PersistStatement)):
+    if not isinstance(
+        final,
+        (SelectStatement, MultiSelectStatement, PersistStatement, ChartStatement),
+    ):
         columns: list[QueryOutColumn] = []
         if enable_performance_logging:
             total_time = time.time() - start_time
@@ -338,7 +352,27 @@ def generate_single_query(
                 f"Parse: {parse_time:.4f}s | "
             )
         return None, columns, None, select_count
-    final_select = final.select if isinstance(final, PersistStatement) else final
+
+    # A chart statement is a bundle of selects, one per layer. Everything below
+    # - column projection, extra filters, concept cleanup - runs off those layer
+    # selects, with the first layer standing in for the result grid, since the
+    # first layer's SQL is what `query_to_output` hands back as `generated_sql`.
+    final_select: SelectStatement | MultiSelectStatement
+    if isinstance(final, ChartStatement):
+        layer_selects = [
+            layer.select for layer in final.layers if layer.select is not None
+        ]
+        if not layer_selects:
+            return None, [], None, select_count
+        final_select = layer_selects[0]
+        candidates = layer_selects
+    else:
+        final_select = final.select if isinstance(final, PersistStatement) else final
+        candidates = (
+            final_select.selects
+            if isinstance(final_select, MultiSelectStatement)
+            else [final_select]
+        )
     # Process columns
     col_start = time.time()
     columns = [
@@ -356,12 +390,6 @@ def generate_single_query(
 
     # Set limits and process filters
     limit_filter_start = time.time()
-
-    candidates = (
-        final_select.selects
-        if isinstance(final_select, MultiSelectStatement)
-        else [final_select]
-    )
 
     # `where_clause` is derived (the AND fold of `where_clauses`) and memoized
     # on the stage list's identity, so extra filters are added by replacing the
@@ -394,12 +422,18 @@ def generate_single_query(
             f"Generation: {gen_time:.4f}s ({safe_percentage(gen_time, total_time):.1f}%)"
         )
     if cleanup_concepts:
-        for k in final_select.locally_derived:
-            perf_logger.info(f"Cleaning up concept: {k}")
-            env.remove_concept(k)
-            if k in pre_concepts:
-                env.add_concept(pre_concepts[k], force=True)
-                # env.concepts[k] = pre_concepts[k]
+        # A chart derives concepts in every layer select (each `<- expr as name`
+        # binding), so all of them have to be swept, not just the first.
+        cleanup_targets: list[SelectStatement | MultiSelectStatement] = (
+            list(candidates) if isinstance(final, ChartStatement) else [final_select]
+        )
+        for cleanup_target in cleanup_targets:
+            for k in cleanup_target.locally_derived:
+                perf_logger.info(f"Cleaning up concept: {k}")
+                env.remove_concept(k)
+                if k in pre_concepts:
+                    env.add_concept(pre_concepts[k], force=True)
+                    # env.concepts[k] = pre_concepts[k]
     return output_statement, columns, default_values, select_count
 
 
@@ -568,6 +602,88 @@ def generate_multi_query_core(
     return all
 
 
+def _serialize_bound_params(
+    bound_params: dict | None,
+) -> dict[str, str | int | float | list] | None:
+    """Bound SQL params, with ListWrapper flattened to a plain list."""
+    if not bound_params:
+        return None
+    return {
+        k: list(v) if isinstance(v, ListWrapper) else v
+        for k, v in bound_params.items()
+        if isinstance(v, (str, int, float, ListWrapper))
+    } or None
+
+
+def _chart_layer_to_output(
+    layer: ProcessedChartLayer, dialect: BaseDialect
+) -> ChartLayerOut:
+    sql: str | None = None
+    parameters: dict[str, str | int | float | list] | None = None
+    if layer.query is not None:
+        sql, bound_params = dialect.compile_statement_with_params(layer.query)
+        parameters = _serialize_bound_params(bound_params)
+    return ChartLayerOut(
+        chart_type=layer.layer_type.value,
+        generated_sql=sql,
+        parameters=parameters,
+        x_fields=list(layer.x_fields),
+        y_fields=list(layer.y_fields),
+        color_field=layer.color_field,
+        size_field=layer.size_field,
+        group_field=layer.group_field,
+        x_trellis_field=layer.x_trellis_field,
+        y_trellis_field=layer.y_trellis_field,
+        geo_field=layer.geo_field,
+        annotation_field=layer.annotation_field,
+        field_labels=dict(layer.field_labels),
+    )
+
+
+def chart_to_output(
+    target: ProcessedChartStatement,
+    columns: list[QueryOutColumn],
+    label: str | None,
+    dialect: BaseDialect,
+    select_count: int | None = None,
+) -> QueryOut:
+    """Project a chart statement onto QueryOut.
+
+    Each layer carries its own SQL, but `generated_sql` is the first layer's
+    so a client that knows nothing about charts still runs something useful
+    and renders the rows as a table.
+    """
+    chart = ChartOut(
+        layers=[_chart_layer_to_output(layer, dialect) for layer in target.layers],
+        placements=[
+            ChartPlacementOut(
+                kind=placement.kind.value,
+                value=(
+                    placement.value
+                    if isinstance(placement.value, (str, int, float, bool))
+                    or placement.value is None
+                    else str(placement.value)
+                ),
+                label=placement.label,
+            )
+            for placement in target.placements
+        ],
+        hide_legend=target.hide_legend,
+        show_title=target.show_title,
+        scale_x=target.scale_x,
+        scale_y=target.scale_y,
+    )
+    primary = chart.layers[0] if chart.layers else None
+    return QueryOut(
+        generated_sql=primary.generated_sql if primary else None,
+        columns=columns,
+        label=label,
+        select_count=select_count,
+        parameters=primary.parameters if primary else None,
+        chart=chart,
+    )
+
+
 def query_to_output(
     target,
     columns,
@@ -596,6 +712,8 @@ def query_to_output(
             label=label,
             select_count=select_count,
         )
+    elif isinstance(target, ProcessedChartStatement):
+        return chart_to_output(target, columns, label, dialect, select_count)
     elif (
         isinstance(target, ProcessedShowStatement)
         and DEFAULT_CONCEPTS["query_text"].address in target.output_columns
@@ -613,13 +731,7 @@ def query_to_output(
         sql, bound_params = dialect.compile_statement_with_params(target)
         compile_time = time.time() - compile_start
         # Serialize params: scalars pass through, ListWrapper exposes .data as a plain list
-        serializable_params: dict[str, str | int | float | list] | None = None
-        if bound_params:
-            serializable_params = {
-                k: list(v) if isinstance(v, ListWrapper) else v
-                for k, v in bound_params.items()
-                if isinstance(v, (str, int, float, ListWrapper))
-            } or None
+        serializable_params = _serialize_bound_params(bound_params)
 
         output = QueryOut(
             generated_sql=sql,

--- a/pyserver/requirements.txt
+++ b/pyserver/requirements.txt
@@ -1,4 +1,4 @@
-pytrilogy>=0.3.327
+pytrilogy>=0.3.335
 fastapi
 click-default-group
 uvicorn

--- a/pyserver/tests/test_app.py
+++ b/pyserver/tests/test_app.py
@@ -10,6 +10,22 @@ from io_models import (
 )
 from studio_endpoints import _generate_query_task
 
+CHART_STATEMENT_QUERY = """
+key id int;
+property id.category string;
+property id.value float;
+
+datasource facts (
+    fact_id: id,
+    category: category,
+    value: value
+)
+grain (id)
+address raw_facts;
+
+chart layer bar (x_axis <- category, y_axis <- sum(value) as total_value);
+"""
+
 
 def test_read_main(test_client: TestClient):
     response = test_client.get("/")
@@ -159,6 +175,44 @@ select unnest(x) as rows;
     assert response.status_code == 200
     # With parameterized rendering, list constants become :x placeholders in SQL
     assert ":x" in response.json()["generated_sql"]
+
+
+def test_generate_query_returns_chart_statement_payload(test_client: TestClient):
+    """A `chart ...` statement has to come back over the wire with both runnable
+    SQL and the chart the author declared, or the studio renders a blank pane."""
+    request = QueryInSchema(
+        imports=[],
+        query=CHART_STATEMENT_QUERY,
+        dialect=Dialects.DUCK_DB,
+        current_filename="test-chart",
+        full_model=ModelInSchema(name="test_parse", sources=[]),
+    )
+
+    response = test_client.post("/generate_query", json=request.model_dump(mode="json"))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["generated_sql"]
+    chart = body["chart"]
+    assert chart["layers"][0]["chart_type"] == "bar"
+    assert chart["layers"][0]["x_fields"] == ["category"]
+    assert chart["layers"][0]["y_fields"] == ["total_value"]
+    assert [c["name"] for c in body["columns"]] == ["category", "total_value"]
+
+
+def test_generate_query_omits_chart_for_plain_select(test_client: TestClient):
+    request = QueryInSchema(
+        imports=[],
+        query="select 1 as rows;",
+        dialect=Dialects.DUCK_DB,
+        current_filename="test-one",
+        full_model=ModelInSchema(name="test_parse", sources=[]),
+    )
+
+    response = test_client.post("/generate_query", json=request.model_dump(mode="json"))
+
+    assert response.status_code == 200
+    assert response.json()["chart"] is None
 
 
 def test_generate_query_worker_serializes_errors():

--- a/pyserver/tests/test_query_core.py
+++ b/pyserver/tests/test_query_core.py
@@ -257,3 +257,127 @@ address regions;
     assert [c.name for c in columns] == ["id", "name"]
     sql = DuckDBDialect().compile_statement(target)
     assert "select" in sql.lower()
+
+
+CHART_MODEL = """
+key id int;
+property id.category string;
+property id.state string;
+property id.value float;
+
+datasource facts (
+    fact_id: id,
+    category: category,
+    state: state,
+    value: value
+)
+grain (id)
+address raw_facts;
+"""
+
+
+def _chart_query(query: str, extra_filters: list[str] | None = None) -> QueryInSchema:
+    return QueryInSchema.model_validate(
+        {
+            "imports": [{"name": "facts", "alias": None}],
+            "query": query,
+            "dialect": "duckdb",
+            "full_model": {
+                "name": "",
+                "sources": [{"alias": "facts", "contents": CHART_MODEL}],
+            },
+            "extra_filters": extra_filters,
+        }
+    )
+
+
+def test_chart_statement_returns_layer_sql_and_roles():
+    dialect = DuckDBDialect()
+    query = _chart_query(
+        "chart layer bar (x_axis <- category, y_axis <- sum(value) as total_value)"
+        " order by total_value desc limit 10;"
+    )
+
+    target, columns, results, select_count = generate_query_core(query, dialect)
+    out = query_to_output(
+        target, columns, results, "default", dialect, False, select_count
+    )
+
+    # One statement, so one select as far as callers policing multi-select input
+    # are concerned - regardless of how many layers it holds.
+    assert select_count == 1
+    assert out.chart is not None
+    assert [c.name for c in out.columns or []] == ["category", "total_value"]
+
+    layer = out.chart.layers[0]
+    assert layer.chart_type == "bar"
+    assert layer.x_fields == ["category"]
+    assert layer.y_fields == ["total_value"]
+    assert layer.field_labels == {"total_value": "total_value"}
+    # The chart's SQL is also the top-level SQL, so a chart-unaware client
+    # still gets a runnable query back.
+    assert layer.generated_sql == out.generated_sql
+    assert "order by" in (out.generated_sql or "").lower()
+
+
+def test_chart_statement_carries_settings_and_placements():
+    dialect = DuckDBDialect()
+    query = _chart_query(
+        "chart set hide_legend set scale_y: log"
+        " layer line (x_axis <- category, y_axis <- sum(value) as tv, color <- state)"
+        " place hline at 5 as target;"
+    )
+
+    target, columns, results, select_count = generate_query_core(query, dialect)
+    out = query_to_output(
+        target, columns, results, "default", dialect, False, select_count
+    )
+
+    assert out.chart is not None
+    assert out.chart.hide_legend is True
+    assert out.chart.scale_y == "log"
+    assert out.chart.layers[0].color_field == "state"
+    placement = out.chart.placements[0]
+    assert (placement.kind, placement.value, placement.label) == ("hline", 5, "target")
+
+
+def test_chart_statement_applies_extra_filters_to_layer_selects():
+    """Cross-filters have to reach the layer select, or a filtered dashboard
+    would silently render unfiltered chart data."""
+    dialect = DuckDBDialect()
+    query = _chart_query(
+        "chart layer bar (x_axis <- category, y_axis <- total_value)"
+        " from select category, sum(value) as total_value;",
+        extra_filters=["state = 'CA'"],
+    )
+
+    target, columns, results, select_count = generate_query_core(query, dialect)
+    out = query_to_output(
+        target, columns, results, "default", dialect, False, select_count
+    )
+
+    assert out.chart is not None
+    assert "'CA'" in (out.chart.layers[0].generated_sql or "")
+
+
+def test_multi_layer_chart_reports_every_layer():
+    dialect = DuckDBDialect()
+    query = _chart_query(
+        "chart layer bar (x_axis <- category, y_axis <- sum(value) as total_value)"
+        " layer line (x_axis <- category, y_axis <- avg(value) as avg_value);"
+    )
+
+    target, columns, results, select_count = generate_query_core(query, dialect)
+    out = query_to_output(
+        target, columns, results, "default", dialect, False, select_count
+    )
+
+    assert out.chart is not None
+    assert [layer.chart_type for layer in out.chart.layers] == ["bar", "line"]
+    assert [layer.y_fields for layer in out.chart.layers] == [
+        ["total_value"],
+        ["avg_value"],
+    ]
+    # Every layer carries its own SQL even though only the first is promoted
+    # to the top-level `generated_sql`.
+    assert all(layer.generated_sql for layer in out.chart.layers)


### PR DESCRIPTION
Trilogy grew first-class chart statements:

```trilogy
chart layer bar (x_axis <- category, y_axis <- sum(value) as total_value)
  order by total_value desc limit 10;
```

The studio dropped them on the floor. `generate_single_query` only recognised `SelectStatement | MultiSelectStatement | PersistStatement`, so a chart statement fell through to `return None, [], None` — `generated_sql: null`, and the editor showed a silent empty result. Nothing in `lib/`, `src/` or `pyserver/` referenced chart statements at all.

## Server

Chart statements are now a bundle of layer selects: columns come from the first layer, extra filters (cross-filters) are applied to **every** layer select, concepts derived in any layer are cleaned up, and a chart counts as one select no matter how many layers it holds.

`QueryOut.chart` carries the layers, their roles, per-layer SQL, placements and settings. Role names on the wire stay pytrilogy's (`x_trellis`, not `trellisRowField`) so the payload is a faithful projection of `ProcessedChartStatement`. `generated_sql` is the first layer's query, so a client that knows nothing about charts still gets something runnable and renders a table.

## Client

`lib/editors/chartStatement.ts` translates the wire spec into the studio's `ChartConfig` — that is the one place the two naming schemes meet. The execution service carries it on `QueryResult` (both the single-query and batch paths), and the editor adopts an authored chart, opening the results pane on Visualize rather than the result grid. Parts the studio can't draw — extra layers, `place hline` — surface as a notice above the chart instead of disappearing.

## Also

- Chart roles (`x_axis`, `y_axis`, `x_trellis`, `y_trellis`) and `set scale_y: log` now highlight in both the Prism and Monarch grammars. The generic roles (`color`, `size`, `geo`, `annotation`) are deliberately left alone: matching them would light up the left-hand side of `auto color <- '#fff';`, which reads identically once the purpose word has been consumed.
- pytrilogy floor raised `0.3.289 → 0.3.335` in `pyproject.toml`, matching `requirements.txt`. `ProcessedChartLayer.field_labels` (the `as` display names this reads) only exists from 0.3.335.

## Tests

- `chartStatement.test.ts` — role translation, the geo/multi-layer/unknown-type cases, and a round trip proving the produced config survives `validateConfigFields` and encodes as expected through `generateVegaSpec` (a config the controls reject is silently replaced by defaults, which would ignore what the author wrote).
- `queryExecutionService.test.ts` — the chart reaches `QueryResult`, and an ordinary select still leaves it unset.
- `test_query_core.py` / `test_app.py` — layer SQL and roles, settings and placements, extra filters reaching the layer select, multi-layer, and the payload over HTTP.
- The basic Trilogy editor Playwright test now runs a chart statement after its select and asserts a rendered Vega canvas.

## Known gaps (deliberate)

Multi-layer charts render layer 1 with a warning — layering N result sets is a real feature, not a wiring fix. Dashboards still ignore `result.chartConfig`; honouring it there would rewrite persisted item config on every refresh. `copy into png '...' from chart ...` returns nothing, which is the gap all `copy` statements already share.

## Worth resolving upstream

- **One `y_axis` per layer, but `ProcessedChartLayer.y_fields` is already a list.** A two-series chart can only be written as two layers — two independent SELECTs. Letting `y_axis <- a, b` bind several fields in one layer needs no model change upstream and maps straight onto the studio's existing `yField2`/`linkY2`.
- **`geo` is a role with no chart type**, and pytrilogy's own Altair renderer raises `NotImplementedError` on it. The studio has a working `geo-map`, so this PR infers it from the presence of a `geo` binding.
- **`tree` and `beeswarm`** exist in the studio with no statement spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzmyESKsWMsfAUHcnnGKpg