### PR TITLE
[Feat] Multi-layer chart rendering (phase A: recursive ChartConfig)

### DIFF
--- a/docs/chart-layering-audit.md
+++ b/docs/chart-layering-audit.md
@@ -1,0 +1,300 @@
+# Audit: Multi-Layer Chart Rendering
+
+Review of `docs/chart-layering-handoff.md` against the code as of `f48816f`, plus the scoping the
+handoff doc is missing. Read the handoff first — this supplements it, it does not replace it.
+
+**Headline:** the handoff is accurate about the data plumbing and inaccurate about the rendering.
+Its central claim — "the per-type builders should not need to change" — is wrong, for four
+independent reasons (params, legends, non-layerable chart types, the point-chart compile step).
+It also scopes the work in the wrong order: it goes straight at multi-*dataset* layering (the
+chart-statement case) when the change the frontend actually wants — recursive `ChartConfig` with
+layers over **one** dataset — is separable, independently shippable, and needs no server work.
+
+---
+
+## 1. Claims verified
+
+These hold up; build on them without re-checking.
+
+| Claim | Verdict |
+| ----- | ------- |
+| Spec builders already emit `layer: []` (`barChartSpec`, `lineAreaSpec`, `pointSpec`, `donutSpec`, `headlineSpec`, `treeSpec`, `mapSpec`) | ✅ |
+| `createBaseSpec` puts one `data: {values}` at the top and every layer inherits it (`spec.ts:53`) | ✅ |
+| Vega-Lite allows per-layer `data`; `width/height: 'container'` must stay top-level; layers can't contain `facet` | ✅ |
+| `ChartLayerOut` has per-layer SQL + roles but no per-layer `columns` (`io_models.py:186`) | ✅ |
+| `chart_to_output` promotes layer 1's SQL and params to the top level (`query_helpers.py:676`) | ✅ |
+| `resolve: {scale: {y: 'independent'}}` is the existing dual-axis knob (`spec.ts:296`) | ✅ |
+| pytrilogy forbids repeated roles per layer, so `y_fields` is capped at 1 (`parsing/v2/rules/chart_rules.py:75`) | ✅ |
+| `CHART_ROLES` has no `y_axis2` — `yField2` is unreachable from the language | ✅ |
+| The trellis restriction is real and enforced upstream (`altair_renderer.py:66`) | ✅ |
+| pytrilogy 0.3.335 is in the repo-root `.venv`; `altair_renderer.py` is the semantics reference | ✅ |
+
+## 2. Claims that are wrong or misleading
+
+**`extractEligibleCrossFilterFields` does not assume one dataset.** `crossFilters.ts:57` takes
+`completionItems: Iterable<{label: string}>` — Monaco completions, not columns. It is not on the
+change list at all. The real single-dataset assumption in that file is downstream, in the
+selection→SQL-filter mapping keyed by item id.
+
+**Per-layer columns cannot be built in `chart_to_output`.** The doc says to build them "the same way
+`generate_single_query` builds them today (from `layer.select.output_components` against `env`)" but
+puts the field on `ChartLayerOut`, which is populated by `_chart_layer_to_output(layer, dialect)` —
+no `env`. Neither `query_to_output` nor either of its two callsites in `studio_endpoints.py`
+(lines 284, 340) has `env` either. The columns have to be built inside `generate_single_query`
+(which has `env` and `layer_selects`, `query_helpers.py:360`) and threaded out through the return
+tuple. That widens `generate_single_query`, `generate_query_core` and `generate_multi_query_core`
+— three signatures and two callsites, not one field.
+
+**"The per-type builders should not need to change" is the doc's load-bearing error.** See §3.
+
+## 3. What the handoff misses
+
+### 3.1 Vega-Lite param names are global — layering the same chart type twice will not compile
+
+Every builder hard-codes its param names: `highlight`, `select`, `brush`. Two bar layers emit two
+params named `highlight` and Vega refuses to compile ("Duplicate signal name"). The codebase
+already knows this — `lineAreaSpec.ts:157` names its secondary-axis param `highlight2` precisely to
+dodge the collision.
+
+Worse, the names are referenced as string literals from three places that don't know about layers:
+
+- `helpers.ts:958` `createInteractionEncodings()` returns `condition: {param: 'select'}` / `'highlight'`
+- `chartHelpers.ts:443` `view.addSignalListener('brush', …)`
+- `lineAreaSpec.ts:41` `transform: [{filter: {param: 'brush'}}]`
+
+**Required:** thread a layer suffix through `createInteractionEncodings(suffix)` and every builder's
+`params`. Recommended rule, which keeps every existing handler working untouched: **layer 0 owns the
+interaction params unsuffixed and is the only interactive layer; layers 1..n get suffixed names and
+no `select`/`brush` params.** That also settles the brushing decision the doc flags as open.
+
+### 3.2 Four chart types don't drop into a Vega-Lite `layer` array as they stand
+
+Ranked by how hard the barrier actually is — an earlier draft of this audit said "cannot at all",
+which overstates it for three of the four:
+
+- **`beeswarm`** (`beeSwarmSpec.ts:110`) is the only genuine format barrier: it returns a raw
+  **Vega** spec — `$schema: .../vega/v6.json`, `data: [ … ]` as an array, `signals`, `scales`,
+  `marks`. Layering it means composing at the Vega level (compile each Vega-Lite layer, merge
+  `marks`/`scales`/`data`), which the codebase already does half of — `spec.ts:410` compiles point
+  charts to Vega today.
+- **`headline`** (`headlineSpec.ts:324`) is ordinary Vega-Lite; it just owns its top-level chrome
+  (`$schema`, `width/height: 'container'`, `config`). Its inner marks are plain unit specs and
+  already namespace their params as `highlight_${index}` / `select_${index}`. Splicing its `layer`
+  array in and dropping the chrome would work.
+- **`tree`/`treemap`** (`treeSpec.ts:22`) — same story, plus it owns its `data` and a stratify
+  pipeline.
+- **`geo-map`** (`mapSpec.ts:496`) carries a `projection`, topojson base layers and nested per-mark
+  `data`. Vega-Lite does allow `projection` on a layer, so this compiles; composing a map with a
+  cartesian chart is just rarely meaningful.
+
+**Decision (v1):** carve them out with a `LAYERABLE_CHART_TYPES` allowlist — `bar`, `barh`, `line`,
+`area`, `point`, `boxplot`, `donut`, `heatmap` — and raise an explicit error when a multi-layer
+config names a type outside it, mirroring how pytrilogy surfaces the trellis restriction rather than
+dropping a layer silently. This is a scope boundary, not a permanent limitation; headline, treemap
+and geo become unwrapping work, and beeswarm becomes Vega-level composition, whenever they're
+wanted. The language's `CHART_TYPE` terminal already excludes `geo-map`, `tree` and `beeswarm`, so
+in v1 the allowlist only bites configs built in the UI or by the LLM.
+
+### 3.3 Point charts compile to Vega at the end of `generateVegaSpec`
+
+`spec.ts:410` runs `compile(spec).spec` and `addLabelTransformToTextMarks` for `chartType === 'point'`.
+In a layered spec that decision is no longer a property of "the" chart type — it's a property of
+*any* layer being a point layer, and the compile has to happen once at the top level after
+stitching, not per layer. Straightforward, but it means `generateVegaSpec`'s tail cannot stay a
+switch on `config.chartType`.
+
+### 3.4 A layered chart needs a series legend, and today's color encoding fights it
+
+Every builder calls `createColorEncoding(config, config.colorField, …)`. N layers with a colorField
+produce N legends; N layers *without* one produce a chart where nothing tells the reader which mark
+is "total" and which is "average" — which is the whole point of `layer bar (…) layer line (…)`.
+
+The Vega-Lite idiom is a constant-datum color per layer plus a shared scale:
+`color: {datum: '<layer label>', type: 'nominal'}` on each layer with
+`resolve: {scale: {color: 'shared'}}`. The label is already on the wire — `ChartLayerOut.field_labels`
+holds the `as` alias, and `altair_renderer.py:92` `_field_title` is the exact precedence to port
+(alias, else the field address, humanized).
+
+Related and unmentioned: with a shared y scale across layers, the **axis title** comes from whichever
+layer Vega-Lite resolves first. Two layers over different measures need either an explicit shared
+title or independent scales.
+
+### 3.5 Nothing decides shared vs independent axes for real layers
+
+The doc says `resolve` "is the same knob" as the `yField2` path — true, but the language has no
+setting for it and the doc proposes no rule. This is a decision that has to be made, not deferred:
+`chart layer bar (y_axis <- total) layer line (y_axis <- average)` almost certainly wants a shared
+y, while `… layer line (y_axis <- margin_pct)` wants an independent one. Suggested rule: shared by
+default; independent when the layers' y fields disagree on format hint (`getFormatHint`,
+`helpers.ts:818`) — i.e. currency vs percent vs plain. Whatever you pick, it needs a
+`linkY2`-equivalent escape hatch on the root config.
+
+### 3.6 A recursive config walks straight into the validators that reset configs
+
+Three places will silently destroy a layered config today:
+
+- `chartHelpers.ts:398` `validateConfigFields` — checks root fields only; a container config with
+  no root `xField`/`yField` and no `hideLegend`/`showTitle` hits the `!anySet && !anyConfigSet`
+  branch and returns `false`.
+- `chartControlsManager.ts:157` `validateAndResetConfig` — on `false`, calls
+  `initializeConfig(…, null, …, force=true)`, which replaces the config with `determineDefaultConfig`
+  output. The layers are gone, and `onChartConfigChange` **persists the flattened result**.
+- `helpers.ts:654` `validateChartConfigForData` → `suggestedConfig` — the same flattening, reached
+  from `chatToolExecutor.ts:152`, `dashboardToolExecutor.ts:344` and
+  `editorRefinementToolExecutor.ts:455`. `dashboardToolExecutor` writes the suggestion back via
+  `updateItemChartConfig`, so an LLM-authored layered chart on a dashboard would be silently
+  rewritten to a single-layer one on the next validation pass.
+
+**These have to be made layer-aware before a recursive config can reach the editor or a dashboard**,
+not after. This is the single biggest correctness risk in the whole change and the handoff does not
+mention it.
+
+Also: `chartControlsManager.ts:63` `applyMissingDefaultsForCurrentChartType` backfills root
+`xField`/`yField` from defaults; on a container config that writes junk into persisted state even if
+rendering ignores it.
+
+### 3.7 `migrateChartConfig` doesn't recurse — and is the wrong home for the `yField2` fold
+
+`results.ts:110` maps deprecated chart-type names at the root only. Once configs nest, it has to
+walk `layers`. That part is straightforward.
+
+The handoff also nominates it as the home for the `yField2` → two-layer conversion. It isn't:
+`migrateChartConfig` has exactly **two callsites, both in `base.ts:1078-1079`**, on dashboard item
+data. Editor configs, LLM-authored configs and statement-authored configs never pass through it, so
+folding `yField2` there would convert one path out of four.
+
+**Do the fold at render time instead.** A `normalizeChartConfig(config)` in `spec.ts` that expands
+`yField2` into a real second layer runs on the single production rendering callsite, so every path
+gets identical treatment with no persistence migration and no risk of rewriting stored configs.
+`yField2` then stays the *authoring* shape (the controls panel and the LLM schema keep it, unchanged)
+while layering becomes the *rendering* model — which is exactly the split that lets
+`barChartSpec`'s and `lineAreaSpec`'s secondary-layer branches be deleted without touching a single
+stored config.
+
+### 3.8 The LLM tool schema is a byte-stability contract
+
+`sharedToolSchemas.ts:39` `chartConfigSchema` is embedded in tool definitions that feed the global
+toolset, which is a **memoized byte-stable union** — the golden test in `toolRegistry.test.ts` is
+the release gate, and tools render before the system prompt, so any edit busts the Anthropic prompt
+cache once. Adding `layers` is fine, but it is a deliberate one-time cache bust plus a golden-test
+update, and it must be a single explicit level of nesting (`layers: {type: 'array', items: <flat
+layer schema>}`) — not a `$ref` self-reference, which tool schemas handle unreliably. The
+`CHART_CONFIG_EXAMPLE` and `chartConfigGuidance` prose need a layered example or the model will
+never emit one.
+
+### 3.9 Not on the doc's file list but affected
+
+- `lib/dashboards/base.ts` (1100 lines) — chart-config-shaped helpers used by the dashboard builder.
+- `lib/dashboards/itemData.ts`, `lib/stores/dashboardStore.ts` — persistence of item chart config.
+- `lib/components/dashboard/DashboardChart.vue:157-210` — spreads config in and out of the store;
+  shallow spread preserves a `layers` reference, so this is safe *if* the controls manager doesn't
+  drop it (see §3.6).
+- `lib/llm/editorRefinementTools.ts:313`, `lib/llm/chatToolExecutor.ts:28` — `chartConfig` on tool
+  inputs and artifacts.
+- `lib/editors/editor.ts:268-291` — `setChartConfig` / `setStatementChartConfig` / serialization.
+
+One genuine piece of good news the doc undersells: **`generateVegaSpec` has exactly one production
+callsite** (`VegaLiteChart.vue:246`). The rendering blast radius is small; it's the config-validation
+and persistence surface that's wide.
+
+---
+
+## 4. Recommended shape
+
+The handoff's suggested shape is sound but sequenced wrong. Split the work in two, because the
+frontend model change you actually want does not depend on the server at all.
+
+### Phase A — recursive `ChartConfig`, one dataset (no server work)
+
+```ts
+export interface ChartConfig {
+  chartType: chartTypes
+  xField?: string
+  // … existing flat fields, all per-layer semantics …
+
+  /** Non-empty ⇒ this config is a container: its own field bindings are
+   *  ignored and only its statement-level settings apply. Absent ⇒ today's
+   *  flat single-layer config, byte-identical. */
+  layers?: ChartConfig[]
+
+  // root-only settings
+  placements?: ChartPlacement[]
+  hideLegend?: boolean
+  showTitle?: boolean
+  scaleX?: 'linear' | 'log' | 'sqrt'
+  scaleY?: 'linear' | 'log' | 'sqrt'
+  linkY2?: boolean
+}
+```
+
+The "container ⇒ root bindings ignored" rule is what keeps every existing config working with zero
+migration: no `layers` key means nothing changes anywhere.
+
+Deliverables:
+
+1. `normalizeChartConfig` in `spec.ts` — one function that turns any config into
+   `{root, layers[]}`, expanding `yField2` into a second layer (§3.7). Single-layer output must stay
+   byte-identical to today's flat spec; the stitching only engages at `layers.length > 1`.
+2. `generateVegaSpec` grows a layered branch: for each layer call the existing per-type builder,
+   apply the param suffix, stitch into `{layer: […]}`, keep `width/height/facet/title/config` at the
+   root, decide `resolve`, and run the point-compile once at the end.
+3. Param namespacing in `createInteractionEncodings` and every builder (§3.1).
+4. `LAYERABLE_CHART_TYPES` allowlist + explicit error (§3.2).
+5. Series-legend encoding (§3.4).
+6. Layer-aware `validateConfigFields`, `validateAndResetConfig`, `validateChartConfigForData` (§3.6).
+7. Recursive `migrateChartConfig` for nested chart-type renames (§3.7).
+8. Delete `barChartSpec`'s `secondaryLineLayer` and `lineAreaSpec`'s `secondaryLayer` branches once
+   the normalizer covers `yField2`. This is a net **deletion** of duplicated surface area — the
+   strongest argument for doing Phase A first.
+
+Phase A alone subsumes definition-of-done item 3, and does it for every chart type at once instead
+of only bar.
+
+### Phase B — N datasets (the chart-statement case)
+
+Everything the handoff describes, on top of A:
+
+8. Per-layer `columns` on the wire — built in `generate_single_query`, threaded through
+   `generate_query_core` / `generate_multi_query_core` (§2).
+9. `QueryResult.layers: {results: Results, columns: Map<…>}[]`; `executeQueryInternal` runs each
+   layer's SQL with that layer's params; `results` keeps pointing at layer 1.
+10. `generateVegaSpec` takes per-layer `{data, columns}` and attaches `data: {values}` per layer.
+    Recommend converting the signature to an options object at this point — it already has nine
+    positional params, and there is one production callsite.
+11. `place hline|vline` → rule + text marks, ported from `altair_renderer.py:157` `_render_placement`.
+12. Trellis-vs-layers restriction, surfaced as an error (`altair_renderer.py:66`).
+13. Delete the warnings in `chartStatementToConfig` and the `chart-statement-warnings` block in
+    `Results.vue:64`.
+
+### Decisions this audit takes a position on
+
+- **Brushing / cross-filter:** layer 0 only, falling out of the param-suffix rule in §3.1. Say it in
+  the PR.
+- **Controls UI:** hide the control panel for any config with `layers` in the first cut. A layer
+  selector is a real feature, not a side effect of this work, and `updateConfig`'s
+  `(field: keyof ChartConfig, value: string|boolean|number)` signature cannot express it anyway.
+- **`yField2`:** fold it at render time, not in persistence (§3.7). It is unreachable from the
+  language (`CHART_ROLES` has no `y_axis2`) and it duplicates layering in two builders, but it stays
+  a valid authoring shape in the controls and the LLM schema.
+- **Dashboards:** don't adopt statement charts (unchanged from PR #250), but §3.6 is a *regression*
+  risk, not an adoption question — the validators must stop flattening before Phase A ships.
+
+## 5. Test additions beyond the handoff's list
+
+The handoff's list is good; add:
+
+- `lib/dashboards/spec.test.ts` — two layers of the **same** chart type compile without duplicate
+  param names (guard for §3.1). Assert against `vega-lite`'s `compile()`, not just spec shape.
+- `lib/dashboards/spec.test.ts` — a non-layerable type in a multi-layer config throws.
+- `lib/components/chartControlsManager.test.ts` + `lib/dashboards/helpers.test.ts` — a layered
+  config survives `validateAndResetConfig` and `validateChartConfigForData` (guard for §3.6).
+- `lib/editors/results.test.ts` — `migrateChartConfig` converts `yField2` to a second layer and
+  recurses into `layers`.
+- `lib/llm/registry/toolRegistry.test.ts` — the golden byte-stability test needs its expected value
+  regenerated in the same commit that touches `chartConfigSchema`.
+
+## 6. Out of scope (additions)
+
+The handoff's list, plus: a layer selector in `ChartControlPanel`, and layered chart **image export**
+(`chartHelpers.ts:64` download path goes through the active Vega view, so it should follow for free,
+but it is untested against multi-dataset specs).

--- a/docs/chart-layering-handoff.md
+++ b/docs/chart-layering-handoff.md
@@ -1,0 +1,224 @@
+# Multi-Layer Chart Rendering — Handoff
+
+Follow-on to PR #250 (`chart-statement-rendering`), which made Trilogy `chart ...` statements
+execute and render in the studio. That PR deliberately renders **only the first layer** and
+reports the rest as a warning. This document is the brief for making the studio genuinely
+render layered charts.
+
+Read PR #250's diff first — `lib/editors/chartStatement.ts`, `pyserver/query_helpers.py`
+(`chart_to_output`) and `lib/dashboards/spec.ts` are the three files this work extends.
+
+## The language being served
+
+```trilogy
+chart
+  set hide_legend
+  set scale_y: log
+  layer bar  (x_axis <- category, y_axis <- sum(value)     as total)
+  layer line (x_axis <- category, y_axis <- avg(value)     as average)
+  place hline at 5 as target;
+```
+
+Grammar (pytrilogy 0.3.335, `trilogy/parsing/trilogy.lark`):
+
+```lark
+chart_layer:     "layer"i CHART_TYPE "(" chart_layer_body ")" ("from"i select_statement)? order_by? limit?
+chart_place:     "place"i CHART_PLACE_TYPE "at"i literal ("as"i IDENTIFIER)?
+chart_statement: "chart"i chart_component+
+```
+
+Each layer compiles to **its own independent SELECT** — different grains, different column sets,
+no requirement that they share an x field. `place hline|vline` is a constant reference line with
+no query behind it at all.
+
+## Why this is tractable
+
+The studio's spec builders **already emit Vega-Lite `layer` arrays**:
+
+| File                             | Existing layering                                                |
+| -------------------------------- | ---------------------------------------------------------------- |
+| `lib/dashboards/barChartSpec.ts` | `{layer: [barLayer, secondaryLineLayer]}` when `yField2` is set  |
+| `lib/dashboards/lineAreaSpec.ts` | base marks + brush-filtered marks, nested `{layer: [...]}` pairs |
+| `lib/dashboards/pointSpec.ts`    | `{layer: base}`                                                  |
+
+What is single is the **data**, in exactly one line: `createBaseSpec(data)` in
+`lib/dashboards/spec.ts` puts one `data: {values: …}` at the top of the spec and every layer
+inherits it. Vega-Lite permits per-layer `data`, so co-rendering N independent result sets is a
+data-model change, not a rendering limitation.
+
+## Definition of done
+
+1. `chart layer bar (…) layer line (…);` renders both layers over their own result sets.
+2. `place hline at 5 as target` draws a labelled rule.
+3. `chart layer bar (x_axis <- a, y_axis <- b) layer line (x_axis <- a, y_axis <- c);` subsumes the
+   `yField2` dual-axis case — it should be the same code path, not a parallel one.
+4. The warnings in `chartStatementToConfig` for extra layers and placements are **deleted**, not
+   reworded — they exist only because of this gap.
+5. A layered chart survives a page reload in the editor (persisted config) and does not corrupt
+   single-dataset charts anywhere else.
+
+## The chain that assumes one dataset
+
+Work outward from the data, not from the spec. Each row is a place that assumes "one result set,
+one column map, one config".
+
+| File                                     | What assumes single                                                                                                                  |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `pyserver/io_models.py`                  | `ChartLayerOut` carries per-layer SQL + roles but **no per-layer `columns`**; `QueryOut.columns` is layer 1's only                   |
+| `pyserver/query_helpers.py`              | `generate_single_query` returns layer 1's columns; `chart_to_output` promotes layer 1's SQL to `generated_sql`                       |
+| `lib/stores/queryExecutionService.ts`    | Executes `queryResult.generated_sql` once; `QueryResult.results` is one `Results`                                                    |
+| `lib/editors/chartStatement.ts`          | Maps `layers[0]` to one flat `ChartConfig`; warns about the rest                                                                     |
+| `lib/editors/results.ts`                 | `ChartConfig` is flat (`xField`, `yField`, `yField2`, …)                                                                             |
+| `lib/dashboards/spec.ts`                 | `createBaseSpec` sets top-level `data`; `generateVegaSpec(data, config, columns, …)` takes one of each                               |
+| `lib/components/VegaLiteChart.vue`       | Props `data: Row[]` + `columns: Map<string, ResultColumn>`                                                                           |
+| `lib/components/chartControlsManager.ts` | `internalConfig` is one `ChartConfig`; `validateAndResetConfig` resets to defaults when fields don't resolve                         |
+| `lib/components/ChartControlPanel.vue`   | Renders `Controls` from `lib/dashboards/constants.ts`, each `field: keyof ChartConfig`                                               |
+| `lib/components/chartHelpers.ts`         | `validateConfigFields(config, columns)`, `handleBrush(name, item, config, columns)`, `setupEventListeners(view, config, columns, …)` |
+| `lib/components/chartRenderManager.ts`   | `renderChart(c1, c2, spec, config, columns, theme, isMobile, brushHandler, title, force)`                                            |
+
+### The one gap that isn't obvious
+
+The wire format from PR #250 gives you per-layer **SQL and roles**, but **not per-layer columns**.
+The chart pipeline needs a `Map<string, ResultColumn>` per layer — `getVegaFieldType`,
+`getFormatHint`, tooltip titles and `::hex` colour scales all resolve fields through it. So
+`ChartLayerOut` needs a `columns: list[QueryOutColumn]` field, built the same way
+`generate_single_query` builds them today (from `layer.select.output_components` against `env`).
+Keep `QueryOut.columns` as layer 1's for back-compat with chart-unaware clients.
+
+Field names on the wire are **safe addresses** (`line_item_return_flag`), which is also the SQL
+alias and therefore the `Results.headers` key. `QueryOutColumn.name` is the dotted address
+(`line_item.return_flag`) and `enrichTrilogyColumns` stores it as `column.address` without
+renaming the key. Do not "fix" this mismatch — the chart config matching header keys is what makes
+`validateConfigFields` pass.
+
+## Reference implementation
+
+pytrilogy renders the same statements with Altair, and its renderer is the closest thing to a
+spec for the semantics:
+
+`.venv/Lib/site-packages/trilogy/rendering/altair_renderer.py`
+
+- `render(statement, layer_data)` — takes **a list of per-layer row sets**, exactly the shape this
+  work needs, and `alt.layer(*layer_charts)`s the results.
+- `_render_layer(layer, data, scales)` — role → encoding channel mapping. Note `x_axis`/`y_axis` are
+  _literal_ axes: for `barh`, `y_axis` is the category, which matches the studio's own `barh`
+  convention (`yField` categorical, `xField` numeric).
+- `_render_placement(placement)` — `mark_rule()` with `alt.datum(value)` on `y` for hline / `x` for
+  vline, plus a `mark_text` label pinned to the rule. Port this shape directly.
+- `_encode` — `set scale_x|scale_y` applies to continuous value axes only; a banded category axis
+  ignores it.
+
+It also enforces a restriction you must reproduce:
+
+> Trellis roles cannot be combined with multiple layers, place rules, or annotations.
+
+That isn't arbitrary — Vega-Lite forbids facet channels inside a layered spec. Detect it and
+surface it as an error, don't silently drop a layer.
+
+## Vega-Lite constraints worth knowing before you design
+
+- Each entry in `layer: []` may carry its own `data: {values: […]}`.
+- `width`/`height: 'container'` must stay on the **top-level** spec, never per layer.
+- Layers cannot contain `facet`; facet must wrap the whole spec (which is why the trellis
+  restriction exists).
+- `resolve: {scale: {y: 'independent'}}` is how the existing `yField2` path gets a dual axis —
+  the same knob decides shared vs independent axes for real layers. `spec.ts` already sets it.
+- Legends across layers with independent data need explicit `color` scales or you get one legend
+  per layer.
+
+## Suggested shape
+
+Not prescriptive, but this keeps the blast radius small:
+
+1. **Server** — add `columns` to `ChartLayerOut`. Extend `pyserver/tests/test_query_core.py`'s
+   `test_multi_layer_chart_reports_every_layer` to assert per-layer columns.
+2. **A layered config type** — `ChartConfig` grows an optional `layers?: LayerConfig[]` (or a
+   sibling `LayeredChartConfig`), where `LayerConfig` is the existing flat shape minus the
+   statement-level settings (`hideLegend`, `showTitle`, `scaleX`, `scaleY`, placements). Keep the
+   flat single-layer shape working untouched — dashboards persist it and `migrateChartConfig`
+   exists for exactly this kind of evolution.
+3. **Execution** — `QueryResult` grows `layers: {results: Results, columns: …}[]`.
+   `executeQueryInternal` runs each `chart.layers[i].generated_sql` (with that layer's
+   `parameters`) instead of only the promoted one. Keep `results` pointing at layer 1 so the
+   results grid and every existing consumer keep working.
+4. **Spec** — `generateVegaSpec` gains a layered path: call the existing per-type builder once per
+   layer with that layer's `config`/`columns`, attach `data: {values}` to each returned layer
+   object, and stitch into `{layer: [...]}`. Placements become additional rule layers. The
+   per-type builders should not need to change.
+5. **Delete the warnings** in `chartStatementToConfig` and the notice rendering in
+   `lib/components/editor/Results.vue` once both cases render.
+
+## Decisions you have to make (flag them, don't guess)
+
+- **Brushing / cross-filter.** `handleBrush` and `extractEligibleCrossFilterFields`
+  (`lib/dashboards/crossFilters.ts`) assume one dataset. What does selecting a region mean when
+  layers have different grains? Simplest defensible answer: brushing applies to layer 1 only, and
+  eligible cross-filter fields come from layer 1's columns. Say so in the PR rather than leaving it
+  implicit.
+- **Controls UI.** `ChartControlPanel.vue` edits one config. Options: hide the controls for
+  statement-authored layered charts (they're authored in code, not the panel), or add a layer
+  selector. Hiding is a legitimate first cut — the statement is the source of truth.
+- **Dashboards.** `dashboardQueryExecutor`'s `onSuccess` takes only `result.results`, and
+  `updateItemChartConfig` persists a single config. PR #250 deliberately left dashboards ignoring
+  `result.chartConfig` because adopting it would rewrite persisted item config on every refresh.
+  Layering does not have to solve that — but don't regress it.
+- **`yField2`.** Folding it into layers is the clean end state; keeping both is duplicate surface
+  area. If you fold it, `migrateChartConfig` in `lib/editors/results.ts` is where the conversion
+  belongs, and `barChartSpec`/`lineAreaSpec`'s secondary-layer branches come out.
+
+## Tests to write
+
+- `lib/editors/chartStatement.test.ts` — a two-layer spec produces two layer configs and **no**
+  warnings; a spec with placements produces placement config and no warning.
+- `lib/dashboards/*.test.ts` — a layered spec emits `layer: [...]` with per-layer `data.values`,
+  and a single-layer chart still emits a flat spec (regression guard for every existing chart).
+- `lib/stores/queryExecutionService.test.ts` — two layers means two `executeSql` calls with the
+  right SQL and each layer's parameters.
+- `pyserver/tests/test_query_core.py` — per-layer columns.
+- `e2e/test-trilogy-editor.spec.ts` — the basic Trilogy editor test already runs a single-layer
+  chart statement; extend it (or add a sibling) with a two-layer statement asserting a rendered
+  canvas. Note the mobile projects stack editor/results into tabs and flip to results when a query
+  starts — `selectAllEditorContent` in that spec clicks `editor-tab` first for this reason.
+
+## Environment notes (learned the hard way in PR #250)
+
+- **Use the repo-root `.venv`** — it has pytrilogy 0.3.335. `pyserver/.venv` is stale at 0.3.211,
+  which predates `chart layer …` entirely and fails to parse it.
+- **The resolver is a separate long-running process.** `.env.development` sets
+  `VITE_RESOLVER_URL=http://127.0.0.1:5678`, so the dev studio talks to your local
+  `python pyserver/main.py`. Editing `query_helpers.py` requires restarting it — vite HMR won't.
+  Then hard-reload the page: `TrilogyResolver` memoizes `/generate_query` responses in an in-page
+  LRU keyed on query text, so a re-run of identical text replays the stale response.
+  A studio pointed at the default hosted resolver (`trilogy-service.fly.dev`) will not have your
+  server changes at all.
+- **`src/` imports lib by relative path** (`../lib/…`), so no `pnpm build:lib` for dev. But lib
+  reads the grammar package's **dist**, so editing `prism-trilogy/src/vocabulary.ts` needs
+  `pnpm build:grammar` before lib tests see it.
+- **`pnpm build` typechecks more than the root does.** `vue-tsc -b` covers lib's tests;
+  `npx vue-tsc --noEmit` does not. Run the former before pushing.
+- **`pnpm build` also regenerates** `lib/llm/data/trilogySyntax.generated.ts` from the installed
+  pytrilogy. Revert it unless you mean to update it.
+- **e2e:** needs pyserver on 5678 and vite on 5173. Warm vite with a request first — a cold first
+  load takes ~25s and Playwright's `goto` gives up at 60s. Run one project at a time locally;
+  seven parallel workers each booting duckdb-wasm produces failures CI (workers: 1) won't show.
+  Webkit-on-Windows also fails the demo-model tests on CORS — that's environmental, not you.
+- **`npx vitest run --exclude "**/providers.integration.test.ts"`** — that suite hits live LLM APIs.
+- **pyserver checks:** `mypy . --explicit-package-bases`, `ruff check . --fix`, `black .` from
+  inside `pyserver/`, per AGENTS.md.
+
+## Out of scope
+
+Dashboard items adopting statement-authored charts; a `geo`/`map` layer type (pytrilogy's own
+renderer raises `NotImplementedError` on the `geo` role — PR #250 infers `geo-map` from the role's
+presence); `copy into png '…' from chart …`, which shares the gap all `copy` statements have.
+
+## Upstream asks that would simplify this
+
+Filed in PR #250's description; repeated here because they change the design if they land.
+
+- **Multiple `y_axis` bindings per layer.** `chart_layer_body` rejects a repeated role, so a
+  two-series chart must be two layers — two independent SELECTs — even when one query would do.
+  `ProcessedChartLayer.y_fields` is _already a list_; only the parser forbids filling it. If this
+  lands, the common dual-series case collapses to one dataset and needs none of the multi-dataset
+  plumbing above.
+- A `map`/`geo` layer type, so `geo` stops being a role that implies a chart type.

--- a/lib/components/VegaLiteChart.vue
+++ b/lib/components/VegaLiteChart.vue
@@ -77,6 +77,7 @@
           <i class="mdi mdi-undo icon"></i>
         </button>
         <button
+          v-if="!isLayeredChart"
           @click="controlsManager.toggleControls"
           class="control-btn"
           :class="{ active: controlsManager.showingControls.value }"
@@ -108,6 +109,7 @@ import {
 } from 'vue'
 import type { PropType } from 'vue'
 import type { ResultColumn, Row, ChartConfig } from '../editors/results'
+import { isLayeredConfig } from '../editors/results'
 import Tooltip from './Tooltip.vue'
 import ChartControlPanel from './ChartControlPanel.vue'
 import type { UserSettingsStoreType } from '../stores/userSettingsStore'
@@ -353,6 +355,12 @@ export default defineComponent({
       )
     }
 
+    // Layered charts are authored as a whole -- by a Trilogy `chart` statement
+    // or an agent -- and the controls panel edits a single flat config, so it
+    // has nothing coherent to offer here. Hide it rather than let it overwrite
+    // the layers.
+    const isLayeredChart = computed(() => isLayeredConfig(controlsManager.internalConfig.value))
+
     const filteredColumnsInternal = (
       type:
         'numeric' | 'categorical' | 'temporal' | 'latitude' | 'longitude' | 'geographic' | 'all',
@@ -485,6 +493,7 @@ export default defineComponent({
       controlsManager,
       renderChart,
       filteredColumnsInternal,
+      isLayeredChart,
       updateConfig,
       openInVegaEditor,
       downloadChart,

--- a/lib/components/chartControlsManager.test.ts
+++ b/lib/components/chartControlsManager.test.ts
@@ -156,4 +156,50 @@ describe('ChartControlsManager', () => {
       expect(manager.internalConfig.value.chartType).toBeDefined()
     })
   })
+
+  describe('layered configs', () => {
+    const layeredConfig = (): ChartConfig => ({
+      chartType: 'bar',
+      layers: [
+        { chartType: 'bar', xField: 'category', yField: 'revenue' },
+        { chartType: 'line', xField: 'category', yField: 'profit' },
+      ],
+    })
+
+    it('takes a layered config verbatim instead of merging single-chart defaults', () => {
+      manager.initializeConfig(testData, testColumns, layeredConfig())
+
+      expect(manager.internalConfig.value.layers).toHaveLength(2)
+      // Root field bindings are meaningless on a container and must not be
+      // backfilled into the config that gets persisted.
+      expect(manager.internalConfig.value.xField).toBeUndefined()
+      expect(manager.internalConfig.value.yField).toBeUndefined()
+    })
+
+    it('does not flatten a layered config on validation', () => {
+      const initial = layeredConfig()
+      manager.initializeConfig(testData, testColumns, initial)
+
+      const valid = manager.validateAndResetConfig(
+        testData,
+        testColumns,
+        (config) => configChanges.push(config),
+        initial,
+      )
+
+      expect(valid).toBe(true)
+      expect(manager.internalConfig.value.layers).toHaveLength(2)
+      // A reset would have fired onChartConfigChange with a flat config and
+      // persisted the flattened result.
+      expect(configChanges).toHaveLength(0)
+    })
+
+    it('reports invalid when a layer references a missing column', () => {
+      const initial = layeredConfig()
+      initial.layers![1].yField = 'not_a_column'
+      manager.initializeConfig(testData, testColumns, initial)
+
+      expect(manager.validateAndResetConfig(testData, testColumns, undefined, initial)).toBe(false)
+    })
+  })
 })

--- a/lib/components/chartControlsManager.ts
+++ b/lib/components/chartControlsManager.ts
@@ -1,6 +1,7 @@
 // chartControlsManager.ts
 import { ref } from 'vue'
 import type { ChartConfig, ResultColumn, Row } from '../editors/results'
+import { isLayeredConfig } from '../editors/results'
 import { determineDefaultConfig } from '../dashboards/helpers'
 import { ChromaChartHelpers } from './chartHelpers'
 
@@ -57,6 +58,12 @@ export class ChartControlsManager {
     data: readonly Row[],
     columns: Map<string, ResultColumn>,
   ): void {
+    // A layered config binds its fields on the sub-layers; backfilling root
+    // field defaults here would write fields the renderer ignores into the
+    // persisted config.
+    if (isLayeredConfig(this.internalConfig.value)) {
+      return
+    }
     const chartType = this.internalConfig.value.chartType
     const defaults = this.getChartTypeDefaults(data, columns, chartType)
     const fieldsToBackfill: Array<keyof ChartConfig> = [
@@ -107,7 +114,13 @@ export class ChartControlsManager {
     onChartConfigChange?: (config: ChartConfig) => void,
     force: boolean = false,
   ): void {
-    if (initialConfig && !force) {
+    if (initialConfig && isLayeredConfig(initialConfig) && !force) {
+      // A layered config is authored as a whole -- by a chart statement or an
+      // agent -- and its field bindings live on the sub-layers. Merging
+      // single-chart defaults into it would only add root fields the renderer
+      // ignores, so take it verbatim.
+      this.internalConfig.value = { ...initialConfig }
+    } else if (initialConfig && !force) {
       const configDefaults = this.getChartTypeDefaults(data, columns, initialConfig.chartType)
       this.internalConfig.value = {
         ...this.internalConfig.value,

--- a/lib/components/chartHelpers.ts
+++ b/lib/components/chartHelpers.ts
@@ -396,6 +396,20 @@ export class ChromaChartHelpers {
    * Validates if configuration fields still exist in columns
    */
   validateConfigFields(config: ChartConfig, columns: Map<string, ResultColumn>): boolean {
+    // A layered config binds its fields on the sub-layers, not on itself. Fall
+    // through to the flat check and it would find nothing set, report invalid,
+    // and the caller would reset the whole chart to defaults -- silently
+    // destroying the layers and persisting the flattened result.
+    if (config.layers && config.layers.length > 0) {
+      let allValid = true
+      for (const layer of config.layers) {
+        if (!this.validateConfigFields(layer, columns)) {
+          allValid = false
+        }
+      }
+      return allValid
+    }
+
     let isValid = true
     let anySet = false
     const fieldsToCheck: FieldKey[] = [

--- a/lib/dashboards/barChartSpec.ts
+++ b/lib/dashboards/barChartSpec.ts
@@ -100,30 +100,9 @@ export const createBarChartSpec = (
     },
   }
 
-  if (!config.yField2) {
-    return barLayer
-  }
-
-  const secondaryLineLayer = {
-    mark: {
-      type: 'line',
-      point: true,
-      color: currentTheme === 'light' ? '#1D4ED8' : '#93C5FD',
-      strokeWidth: 2,
-    },
-    encoding: {
-      x: buildXEncoding(labelAngle),
-      y: createFieldEncoding(config.yField2, columns, {
-        axis: {
-          ...getFormatHint(config.yField2, columns),
-          orient: 'right',
-        },
-      }),
-      tooltip: tooltipFields,
-    },
-  }
-
-  return {
-    layer: [barLayer, secondaryLineLayer],
-  }
+  // `yField2` no longer branches here: `normalizeChartConfig` expands it into a
+  // real second layer before this builder is called, so a bar chart is always
+  // exactly one mark and the dual-axis case goes through the generic layering
+  // path like any other multi-layer chart.
+  return barLayer
 }

--- a/lib/dashboards/constants.ts
+++ b/lib/dashboards/constants.ts
@@ -16,6 +16,30 @@ export const TRELLIS_ELIGIBLE: chartTypes[] = ['line', 'area', 'bar', 'barh', 'p
 // Chart types that don't have axes (no axis labels or ticks)
 export const NO_AXES_CHARTS: chartTypes[] = ['geo-map', 'tree', 'donut', 'headline']
 
+/**
+ * Chart types whose spec builders emit a Vega-Lite unit spec that can be
+ * dropped straight into a `layer: []` array.
+ *
+ * The exclusions are a v1 scope boundary, not a permanent limitation:
+ *  - `beeswarm` emits a raw *Vega* spec (signals/scales/marks), so layering it
+ *    needs Vega-level composition rather than a Vega-Lite layer array.
+ *  - `headline` and `tree` emit ordinary Vega-Lite but own their top-level
+ *    chrome (`$schema`, container sizing, `config`) and their own `data`;
+ *    they would need unwrapping first.
+ *  - `geo-map` carries a projection and topojson base layers -- legal in a
+ *    layer, but rarely meaningful next to a cartesian chart.
+ */
+export const LAYERABLE_CHART_TYPES: chartTypes[] = [
+  'bar',
+  'barh',
+  'line',
+  'area',
+  'point',
+  'boxplot',
+  'donut',
+  'heatmap',
+]
+
 export const Controls: ChartControl[] = [
   {
     id: 'group-by',

--- a/lib/dashboards/helpers.test.ts
+++ b/lib/dashboards/helpers.test.ts
@@ -10,6 +10,7 @@ import {
   getColumnHasTrait,
   columHasTraitEnding,
   getGeoTraitType,
+  validateChartConfigForData,
 } from './helpers'
 import { type Row, type ResultColumn } from '../editors/results'
 import { ColumnType } from '../editors/results'
@@ -888,5 +889,65 @@ describe('Chart Utils', () => {
       const defaults = determineDefaultConfig(sampleData, numericOnlyColumns, 'geo-map')
       expect(defaults.chartType).toBe('geo-map')
     })
+  })
+})
+
+describe('validateChartConfigForData with layers', () => {
+  const columns = new Map<string, ResultColumn>([
+    ['category', { name: 'category', type: ColumnType.STRING, traits: [] }],
+    ['total', { name: 'total', type: ColumnType.NUMBER, traits: [] }],
+    ['average', { name: 'average', type: ColumnType.NUMBER, traits: [] }],
+  ])
+  const data: Row[] = [
+    { category: 'a', total: 10, average: 4 },
+    { category: 'b', total: 20, average: 6 },
+  ]
+
+  const layered = () => ({
+    chartType: 'bar' as const,
+    layers: [
+      { chartType: 'bar' as const, xField: 'category', yField: 'total' },
+      { chartType: 'line' as const, xField: 'category', yField: 'average' },
+    ],
+  })
+
+  it('validates a well-formed layered config without flattening it', () => {
+    const result = validateChartConfigForData(data, columns, layered())
+
+    expect(result.valid).toBe(true)
+    // Callers write suggestedConfig straight back to the store, so it must
+    // keep the layers rather than collapse to a single-layer default.
+    expect((result.suggestedConfig as any).layers).toHaveLength(2)
+  })
+
+  it('reports which layer references a missing column', () => {
+    const config = layered()
+    config.layers[1].yField = 'not_a_column'
+
+    const result = validateChartConfigForData(data, columns, config)
+
+    expect(result.valid).toBe(false)
+    expect(result.fieldErrors.join(' ')).toContain('Layer 2')
+    expect((result.suggestedConfig as any).layers).toHaveLength(2)
+  })
+
+  it('rejects a chart type that cannot be a layer', () => {
+    const config = layered()
+    ;(config.layers[1] as any).chartType = 'headline'
+
+    const result = validateChartConfigForData(data, columns, config)
+
+    expect(result.valid).toBe(false)
+    expect(result.fieldErrors.join(' ')).toContain('cannot be used as a layer')
+  })
+
+  it('rejects trellis combined with layers', () => {
+    const result = validateChartConfigForData(data, columns, {
+      ...layered(),
+      trellisField: 'category',
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.fieldErrors.join(' ')).toContain('Trellis roles cannot be combined')
   })
 })

--- a/lib/dashboards/helpers.ts
+++ b/lib/dashboards/helpers.ts
@@ -1,7 +1,7 @@
 import { type Row, type ResultColumn } from '../editors/results'
-import { type ChartConfig } from '../editors/results'
+import { type ChartConfig, LAYER_FIELD_KEYS } from '../editors/results'
 import { ColumnType } from '../editors/results'
-import { Charts, Controls } from './constants'
+import { Charts, Controls, LAYERABLE_CHART_TYPES } from './constants'
 import { snakeCaseToCapitalizedWords } from './formatting'
 import { type FieldEncodingOutput } from './types'
 
@@ -234,7 +234,13 @@ export const determineDefaultConfig = (
     | 'donut',
 ): Partial<ChartConfig> => {
   const defaults: Partial<ChartConfig> = {
-    showTitle: true,
+    // `showTitle` used to be a no-op wherever no `chartTitle` was supplied --
+    // which is every chart in the editor -- so defaulting it on was invisible.
+    // Now that it synthesizes a title from the chart's own fields, defaulting
+    // it on would put a title above every auto-configured chart. Titles stay
+    // opt-in: dashboards set it with the item name, `set show_title` sets it
+    // from a chart statement, and the controls panel exposes it.
+    showTitle: false,
     hideLegend: false,
   }
 
@@ -659,6 +665,59 @@ export const validateChartConfigForData = (
   const eligible = determineEligibleChartTypes(data, columns)
   const fieldErrors: string[] = []
 
+  // A layered config binds its fields on the sub-layers. Validating it flat
+  // would find no fields set, fail, and hand back a flat `suggestedConfig` that
+  // callers write straight back to the store -- silently collapsing the chart
+  // to a single layer. Validate each layer instead and keep the layers intact.
+  if (config.layers && config.layers.length > 0) {
+    const layerErrors: string[] = []
+    const availableColumns = Array.from(columns.keys())
+
+    config.layers.forEach((layer, i) => {
+      const prefix = `Layer ${i + 1}`
+
+      if (!LAYERABLE_CHART_TYPES.includes(layer.chartType)) {
+        layerErrors.push(
+          `${prefix}: chart type "${layer.chartType}" cannot be used as a layer. ` +
+            `Layerable types: ${LAYERABLE_CHART_TYPES.join(', ')}.`,
+        )
+      }
+
+      // Deliberately *not* gated on `determineEligibleChartTypes`: that is an
+      // auto-suggestion heuristic for picking a chart type from data shape, and
+      // a layered chart is an explicit authoring choice. Combining a bar and a
+      // line over a categorical axis is the language's motivating example and
+      // the heuristic would reject the line half of it.
+      for (const key of LAYER_FIELD_KEYS) {
+        const val = layer[key]
+        if (typeof val === 'string' && val !== '' && !columns.has(val)) {
+          layerErrors.push(
+            `${prefix}: field "${val}" (${key}) does not exist in the query results. ` +
+              `Available columns: ${availableColumns.join(', ')}.`,
+          )
+        }
+      }
+
+      if (!layer.xField && !layer.yField) {
+        layerErrors.push(`${prefix}: needs at least one of xField or yField.`)
+      }
+    })
+
+    if (config.trellisField || config.trellisRowField) {
+      layerErrors.push('Trellis roles cannot be combined with multiple layers or reference lines.')
+    }
+
+    return {
+      valid: layerErrors.length === 0,
+      fieldErrors: layerErrors,
+      eligibleChartTypes: eligible,
+      // No auto-correction for layered configs: the layers are authored as a
+      // unit, and handing back a flattened default would silently discard them
+      // in the callers that persist `suggestedConfig`.
+      suggestedConfig: config,
+    }
+  }
+
   // Check if the chart type is eligible for this data
   if (!eligible.includes(config.chartType)) {
     const fieldSummary = describeFieldTypes(columns)
@@ -955,21 +1014,36 @@ export const createFieldEncoding = (
 /**
  * Create standard opacity and stroke width encoding for interaction
  */
-export const createInteractionEncodings = () => {
+/**
+ * Vega param names are global to a spec, so layering two charts of the same
+ * type would otherwise emit two params called `highlight` and fail to compile.
+ * Every builder takes a layer suffix and every reference to a param name goes
+ * through these helpers.
+ *
+ * Layer 0 gets the empty suffix on purpose: it keeps the unsuffixed names that
+ * `chartHelpers.setupEventListeners` and the brush filter transforms listen
+ * for, so it stays the interactive layer and no handler needs to change.
+ */
+export const layerParamSuffix = (layerIndex: number = 0): string =>
+  layerIndex > 0 ? `_l${layerIndex}` : ''
+
+export const paramName = (base: string, suffix: string = ''): string => `${base}${suffix}`
+
+export const createInteractionEncodings = (suffix: string = '') => {
   return {
     fillOpacity: {
-      condition: { param: 'select', value: 1 },
+      condition: { param: paramName('select', suffix), value: 1 },
       value: 0.3,
     },
     strokeWidth: {
       condition: [
         {
-          param: 'select',
+          param: paramName('select', suffix),
           empty: false,
           value: 2,
         },
         {
-          param: 'highlight',
+          param: paramName('highlight', suffix),
           empty: false,
           value: 1,
         },
@@ -1014,6 +1088,13 @@ export const createColorEncoding = (
   currentTheme: string = 'light',
   hideLegend: boolean = false,
   data: readonly Row[] | null = [],
+  /**
+   * Which layer's selection params drive the highlight condition. `''` is the
+   * interactive layer 0 and keeps today's unsuffixed names; `null` emits no
+   * condition at all, which is what non-interactive layers need -- referencing
+   * a param that layer doesn't declare fails Vega-Lite compilation.
+   */
+  paramSuffix: string | null = '',
 ) => {
   let legendConfig = { tickCount: legendTicks }
   let uniqueValues: any[] = []
@@ -1089,10 +1170,14 @@ export const createColorEncoding = (
       type: fieldType,
       title: snakeCaseToCapitalizedWords(columns.get(colorField)?.description || colorField),
       scale: scale,
-      condition: [
-        { param: 'highlight', empty: false, value: HIGHLIGHT_COLOR },
-        { param: 'select', empty: false, value: HIGHLIGHT_COLOR },
-      ],
+      ...(paramSuffix === null
+        ? {}
+        : {
+            condition: [
+              { param: paramName('highlight', paramSuffix), empty: false, value: HIGHLIGHT_COLOR },
+              { param: paramName('select', paramSuffix), empty: false, value: HIGHLIGHT_COLOR },
+            ],
+          }),
       ...getFormatHint(colorField, columns),
     }
 

--- a/lib/dashboards/layerSpec.test.ts
+++ b/lib/dashboards/layerSpec.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from 'vitest'
+import { compile } from 'vega-lite'
+import { generateVegaSpec } from './spec'
+import {
+  normalizeChartConfig,
+  resolveLayerYScale,
+  deriveChartTitle,
+  UnlayerableChartTypeError,
+} from './layerSpec'
+import { ColumnType, type ChartConfig, type ResultColumn, type Row } from '../editors/results'
+
+const columns = new Map<string, ResultColumn>([
+  ['category', { name: 'category', type: ColumnType.STRING, description: 'Category' }],
+  ['total', { name: 'total', type: ColumnType.NUMBER, description: 'Total' }],
+  ['average', { name: 'average', type: ColumnType.NUMBER, description: 'Average' }],
+  ['pct', { name: 'pct', type: ColumnType.NUMBER, description: 'Pct', traits: ['percent'] }],
+  ['region', { name: 'region', type: ColumnType.STRING, description: 'Region' }],
+  ['sum_charge', { name: 'sum_charge', type: ColumnType.NUMBER }],
+])
+
+const data: Row[] = [
+  { category: 'a', total: 10, average: 4, pct: 0.1, region: 'east' },
+  { category: 'b', total: 20, average: 6, pct: 0.4, region: 'west' },
+]
+
+const layered = (over: Partial<ChartConfig> = {}): ChartConfig => ({
+  chartType: 'bar',
+  layers: [
+    { chartType: 'bar', xField: 'category', yField: 'total' },
+    { chartType: 'line', xField: 'category', yField: 'average' },
+  ],
+  ...over,
+})
+
+describe('normalizeChartConfig', () => {
+  it('leaves an ordinary config as a single layer', () => {
+    const config: ChartConfig = { chartType: 'bar', xField: 'category', yField: 'total' }
+    const { root, layers } = normalizeChartConfig(config)
+
+    expect(layers).toHaveLength(1)
+    expect(layers[0]).toBe(config)
+    expect(root).toBe(config)
+  })
+
+  it('expands yField2 on a bar chart into a real second layer', () => {
+    const config: ChartConfig = {
+      chartType: 'bar',
+      xField: 'category',
+      yField: 'total',
+      yField2: 'pct',
+    }
+    const { layers } = normalizeChartConfig(config)
+
+    expect(layers).toHaveLength(2)
+    expect(layers[0].yField2).toBeUndefined()
+    expect(layers[1]).toMatchObject({
+      chartType: 'line',
+      xField: 'category',
+      yField: 'pct',
+      yAxisOrient: 'right',
+    })
+  })
+
+  it('shares the axis instead of orienting right when linkY2 is set', () => {
+    const { root, layers } = normalizeChartConfig({
+      chartType: 'bar',
+      xField: 'category',
+      yField: 'total',
+      yField2: 'pct',
+      linkY2: true,
+    })
+
+    expect(layers[1].yAxisOrient).toBeUndefined()
+    expect(root.linkLayerY).toBe(true)
+  })
+
+  it('leaves line charts owning their own yField2 handling', () => {
+    const config: ChartConfig = {
+      chartType: 'line',
+      xField: 'category',
+      yField: 'total',
+      yField2: 'pct',
+    }
+    expect(normalizeChartConfig(config).layers).toHaveLength(1)
+  })
+
+  it('pushes statement-level settings down onto every layer', () => {
+    const { layers } = normalizeChartConfig(layered({ hideLegend: true, scaleY: 'log' }))
+
+    expect(layers.every((layer) => layer.hideLegend === true)).toBe(true)
+    expect(layers.every((layer) => layer.scaleY === 'log')).toBe(true)
+  })
+})
+
+describe('resolveLayerYScale', () => {
+  it('shares the scale when the layers measure the same kind of thing', () => {
+    const { root, layers } = normalizeChartConfig(layered())
+    expect(resolveLayerYScale(root, layers, columns)).toBe('shared')
+  })
+
+  it('goes independent when the layers disagree on format', () => {
+    const config = layered()
+    config.layers![1].yField = 'pct'
+    const { root, layers } = normalizeChartConfig(config)
+    expect(resolveLayerYScale(root, layers, columns)).toBe('independent')
+  })
+
+  it('honours an explicit linkLayerY override', () => {
+    const config = layered({ linkLayerY: true })
+    config.layers![1].yField = 'pct'
+    const { root, layers } = normalizeChartConfig(config)
+    expect(resolveLayerYScale(root, layers, columns)).toBe('shared')
+  })
+})
+
+describe('generateVegaSpec with layers', () => {
+  it('emits one entry per layer', () => {
+    const spec: any = generateVegaSpec(data, layered(), columns, null)
+
+    expect(spec.layer).toHaveLength(2)
+    expect(spec.layer[1].mark.type).toBe('line')
+    expect(spec.layer[1].encoding.y.field).toBe('average')
+  })
+
+  it('compiles without duplicate param names when layering the same chart type', () => {
+    const sameType = layered()
+    sameType.layers![1].chartType = 'bar'
+
+    const spec: any = generateVegaSpec(data, sameType, columns, null)
+    // Duplicate Vega param names are a compile-time failure, not a shape
+    // problem, so this has to go all the way through vega-lite.
+    expect(() => compile(spec)).not.toThrow()
+  })
+
+  it('gives the layers a shared series legend naming each one', () => {
+    const spec: any = generateVegaSpec(data, layered(), columns, null)
+
+    expect(spec.layer[0].encoding.color.datum).toBe('Total')
+    expect(spec.layer[1].encoding.color.datum).toBe('Average')
+  })
+
+  it('does not add a series legend when a layer colours by a field', () => {
+    const config = layered()
+    config.layers![0].colorField = 'region'
+
+    const spec: any = generateVegaSpec(data, config, columns, null)
+    expect(spec.layer[1].encoding.color?.datum).toBeUndefined()
+  })
+
+  it('omits selection conditions on non-interactive layers', () => {
+    const config = layered()
+    config.layers![1].colorField = 'region'
+
+    const spec: any = generateVegaSpec(data, config, columns, null)
+    // Layer 1 declares no params, so conditioning on `select`/`highlight`
+    // would reference params that do not exist in its scope.
+    expect(spec.layer[1].encoding.color.condition).toBeUndefined()
+    expect(() => compile(spec)).not.toThrow()
+  })
+
+  it('renders placements as labelled rule layers', () => {
+    const config = layered({ placements: [{ kind: 'hline', value: 5, label: 'target' }] })
+    const spec: any = generateVegaSpec(data, config, columns, null)
+
+    const rule = spec.layer.find((l: any) => l.mark?.type === 'rule')
+    const label = spec.layer.find((l: any) => l.mark?.type === 'text')
+    expect(rule.encoding.y.datum).toBe(5)
+    expect(label.encoding.text.value).toBe('target')
+  })
+
+  it('rejects a trellis combined with layers instead of dropping one', () => {
+    expect(() =>
+      generateVegaSpec(data, layered({ trellisField: 'region' }), columns, null),
+    ).toThrow(/Trellis roles cannot be combined/)
+  })
+
+  it('rejects a chart type that cannot be a layer', () => {
+    const config = layered()
+    config.layers![1].chartType = 'headline'
+
+    expect(() => generateVegaSpec(data, config, columns, null)).toThrow(UnlayerableChartTypeError)
+  })
+
+  it('leaves a single-layer chart as a flat spec', () => {
+    const spec: any = generateVegaSpec(
+      data,
+      { chartType: 'bar', xField: 'category', yField: 'total' },
+      columns,
+      null,
+    )
+
+    expect(spec.layer).toBeUndefined()
+    expect(spec.encoding.x.field).toBe('category')
+  })
+})
+
+describe('chart titles', () => {
+  it('derives from the value axis, humanized', () => {
+    // 'total' has description 'Total'; a field with no description falls back
+    // to the field name itself.
+    expect(
+      deriveChartTitle([{ chartType: 'bar', xField: 'category', yField: 'total' }], columns),
+    ).toBe('Total')
+    expect(
+      deriveChartTitle([{ chartType: 'bar', xField: 'category', yField: 'sum_charge' }], columns),
+    ).toBe('Sum Charge')
+  })
+
+  it('falls back to the category axis when there is no value axis', () => {
+    expect(deriveChartTitle([{ chartType: 'bar', xField: 'category' }], columns)).toBe('Category')
+  })
+
+  it('takes the first layer that binds a field', () => {
+    const { layers } = normalizeChartConfig(layered())
+    expect(deriveChartTitle(layers, columns)).toBe('Total')
+  })
+
+  it('returns empty when nothing is bound', () => {
+    expect(deriveChartTitle([{ chartType: 'headline' }], columns)).toBe('')
+  })
+
+  it('shows a derived title when showTitle is set and no title is supplied', () => {
+    // This is the `set show_title` case: the editor never passes a chartTitle,
+    // so before this the flag rendered nothing at all.
+    const spec: any = generateVegaSpec(
+      data,
+      { chartType: 'bar', xField: 'category', yField: 'total', showTitle: true },
+      columns,
+      null,
+    )
+    expect(spec.title.text).toBe('Total')
+  })
+
+  it('prefers an explicitly supplied title', () => {
+    const spec: any = generateVegaSpec(
+      data,
+      { chartType: 'bar', xField: 'category', yField: 'total', showTitle: true },
+      columns,
+      null,
+      false,
+      'Revenue by Region',
+    )
+    expect(spec.title.text).toBe('Revenue by Region')
+  })
+
+  it('shows no title when showTitle is unset', () => {
+    const spec: any = generateVegaSpec(
+      data,
+      { chartType: 'bar', xField: 'category', yField: 'total' },
+      columns,
+      null,
+    )
+    expect(spec.title).toBeUndefined()
+  })
+
+  it('titles a layered chart from its first layer', () => {
+    const spec: any = generateVegaSpec(data, layered({ showTitle: true }), columns, null)
+    expect(spec.title.text).toBe('Total')
+  })
+})

--- a/lib/dashboards/layerSpec.ts
+++ b/lib/dashboards/layerSpec.ts
@@ -1,0 +1,371 @@
+/**
+ * Multi-layer chart rendering.
+ *
+ * A `ChartConfig` with a non-empty `layers` array is a *container*: its own
+ * field bindings are ignored and it contributes only statement-level settings
+ * (title, legend, scales, reference lines). Each entry in `layers` is a chart
+ * config in its own right and becomes one Vega-Lite layer.
+ *
+ * Two rules keep this compatible with everything that came before:
+ *
+ *  - **Layer 0 is the interactive layer.** It keeps the unsuffixed `highlight`
+ *    / `select` / `brush` param names, so `chartHelpers.setupEventListeners`,
+ *    the brush filter transforms and cross-filtering all keep working without
+ *    knowing layers exist. Layers 1..n get suffixed params and no selections.
+ *  - **A single layer is not a layered spec.** `normalizeChartConfig` returns
+ *    one layer for an ordinary config and the caller renders it exactly as it
+ *    did before, so no existing chart changes shape.
+ */
+import { type Row, type ResultColumn, type ChartConfig } from '../editors/results'
+import { isLayeredConfig } from '../editors/results'
+import {
+  createFieldEncoding,
+  createColorEncoding,
+  createSizeEncoding,
+  getFormatHint,
+  getSortOrder,
+  hasDiscreteTimeTrait,
+  layerParamSuffix,
+} from './helpers'
+import { LAYERABLE_CHART_TYPES, lightDefaultColor, darkDefaultColor } from './constants'
+import { snakeCaseToCapitalizedWords } from './formatting'
+
+/** Thrown when a config asks for a chart type that can't be a Vega-Lite layer. */
+export class UnlayerableChartTypeError extends Error {
+  constructor(public readonly chartType: string) {
+    super(
+      `Chart type '${chartType}' cannot be used as a layer. ` +
+        `Layerable types: ${LAYERABLE_CHART_TYPES.join(', ')}.`,
+    )
+    this.name = 'UnlayerableChartTypeError'
+  }
+}
+
+export interface NormalizedChartConfig {
+  /** Statement-level settings: title, legend, scales, placements. */
+  root: ChartConfig
+  /** One entry per rendered layer. Length 1 means "not a layered chart". */
+  layers: ChartConfig[]
+}
+
+/**
+ * Resolve any config into a root plus its layers.
+ *
+ * This is also where `yField2` becomes a real second layer, rather than in
+ * `migrateChartConfig`: that only runs on dashboard item data, whereas every
+ * chart -- editor, dashboard, LLM-authored, statement-authored -- renders
+ * through here. `yField2` therefore stays a valid *authoring* shape (the
+ * controls panel and the LLM tool schema keep it) while layering is the
+ * *rendering* model.
+ *
+ * The fold is deliberately limited to `bar`: it is the only chart type whose
+ * secondary series is a plain mark. `line`/`area` build their secondary series
+ * with their own brush-linked base/filtered pair, which the generic layer
+ * machinery does not reproduce, so they keep owning `yField2` for now.
+ */
+export const normalizeChartConfig = (config: ChartConfig): NormalizedChartConfig => {
+  if (isLayeredConfig(config)) {
+    // Statement-level settings live on the container but every downstream
+    // builder reads them off the config it is handed, so push them down. This
+    // is what lets layer 0 take the ordinary single-chart code path untouched.
+    const inherited = {
+      hideLegend: config.hideLegend,
+      showTitle: config.showTitle,
+      scaleX: config.scaleX,
+      scaleY: config.scaleY,
+    }
+    return {
+      root: config,
+      layers: (config.layers as ChartConfig[]).map((layer) => ({ ...inherited, ...layer })),
+    }
+  }
+
+  if (config.yField2 && config.chartType === 'bar') {
+    const independent = !config.linkY2
+    return {
+      root: { ...config, linkLayerY: !independent },
+      layers: [
+        { ...config, yField2: undefined },
+        {
+          chartType: 'line',
+          xField: config.xField,
+          yField: config.yField2,
+          hideLegend: config.hideLegend,
+          scaleY: config.scaleY,
+          ...(independent ? { yAxisOrient: 'right' as const } : {}),
+          layerLabel: config.yField2,
+        },
+      ],
+    }
+  }
+
+  return { root: config, layers: [config] }
+}
+
+/**
+ * Should the layers share one y scale, or get independent ones?
+ *
+ * The language has no setting for this, so it is inferred: layers whose value
+ * axes disagree on format (currency vs percent vs plain) are measuring
+ * different things and get independent scales; otherwise they share, which is
+ * what makes `layer bar (total) layer line (average)` comparable. `linkLayerY`
+ * on the root overrides either way.
+ */
+export const resolveLayerYScale = (
+  root: ChartConfig,
+  layers: ChartConfig[],
+  columns: Map<string, ResultColumn>,
+): 'shared' | 'independent' => {
+  if (root.linkLayerY === true) return 'shared'
+  if (root.linkLayerY === false) return 'independent'
+  if (layers.some((layer) => layer.yAxisOrient === 'right')) return 'independent'
+
+  const formats = new Set(
+    layers.map((layer) => JSON.stringify(getFormatHint(layer.yField, columns) || {})),
+  )
+  return formats.size > 1 ? 'independent' : 'shared'
+}
+
+/** Display name for a layer in the series legend. */
+export const layerSeriesLabel = (
+  layer: ChartConfig,
+  columns: Map<string, ResultColumn>,
+  index: number,
+): string => {
+  if (layer.layerLabel) return layer.layerLabel
+  const field = layer.yField || layer.xField
+  if (field) {
+    return columns.get(field)?.description || field
+  }
+  return `Layer ${index + 1}`
+}
+
+/**
+ * Title for a chart that asked for one but wasn't given a string.
+ *
+ * `showTitle` used to mean "render the title someone else handed me", which is
+ * why `set show_title` on a Trilogy chart statement did nothing in the editor:
+ * only dashboards pass a `chartTitle`. It now means "show a title", with an
+ * explicit one winning and this standing in otherwise.
+ *
+ * The precedence is pytrilogy's (`AltairRenderer._statement_title`): the first
+ * layer's value axis, falling back to its category axis, humanized -- so the
+ * studio and `trilogy` render the same statement with the same title.
+ */
+export const deriveChartTitle = (
+  layers: ChartConfig[],
+  columns: Map<string, ResultColumn>,
+): string => {
+  for (const layer of layers) {
+    for (const field of [layer.yField, layer.xField]) {
+      if (!field) continue
+      const label = layer.layerLabel || columns.get(field)?.description || field
+      if (label) return snakeCaseToCapitalizedWords(label)
+    }
+  }
+  return ''
+}
+
+const MARK_TYPE_BY_CHART: Partial<Record<ChartConfig['chartType'], string>> = {
+  bar: 'bar',
+  barh: 'bar',
+  line: 'line',
+  area: 'area',
+  point: 'point',
+  boxplot: 'boxplot',
+  donut: 'arc',
+  heatmap: 'rect',
+}
+
+const layerMark = (
+  layer: ChartConfig,
+  currentTheme: 'light' | 'dark' | '',
+  seriesColored: boolean,
+): any => {
+  const type = MARK_TYPE_BY_CHART[layer.chartType]
+  const mark: any = { type }
+
+  if (layer.chartType === 'line' || layer.chartType === 'point') {
+    mark.point = layer.chartType === 'line' ? true : undefined
+    if (mark.point === undefined) delete mark.point
+  }
+  if (layer.chartType === 'line') {
+    mark.strokeWidth = 2
+  }
+  if (layer.chartType === 'area') {
+    mark.opacity = 0.7
+  }
+  if (layer.chartType === 'boxplot') {
+    mark.extent = 'min-max'
+  }
+
+  // A series-coloured layer takes its colour from the shared colour scale; a
+  // lone layer keeps the theme's default mark colour.
+  if (!seriesColored && !layer.colorField) {
+    mark.color = currentTheme === 'light' ? lightDefaultColor : darkDefaultColor
+  }
+  return mark
+}
+
+/**
+ * Build one Vega-Lite unit spec for a single layer.
+ *
+ * This is deliberately *not* the full per-type builder: those carry brush
+ * scaffolding, faceting and container chrome that belong to the top-level spec
+ * and cannot be repeated per layer. A layer is a mark plus its encodings.
+ */
+export const createLayerMarkSpec = (
+  layer: ChartConfig,
+  columns: Map<string, ResultColumn>,
+  tooltipFields: any[],
+  data: readonly Row[] | null,
+  options: {
+    layerIndex: number
+    currentTheme: 'light' | 'dark' | ''
+    isMobile: boolean
+    seriesLabel?: string
+    hideLegend?: boolean
+    scaleX?: ChartConfig['scaleX']
+    scaleY?: ChartConfig['scaleY']
+  },
+): any => {
+  if (!LAYERABLE_CHART_TYPES.includes(layer.chartType)) {
+    throw new UnlayerableChartTypeError(layer.chartType)
+  }
+
+  const { layerIndex, currentTheme, isMobile, seriesLabel } = options
+  const suffix = layerParamSuffix(layerIndex)
+
+  // `barh` swaps the axis roles: its yField is the category and xField the
+  // measure, matching the language's literal x_axis/y_axis semantics.
+  const isHorizontal = layer.chartType === 'barh'
+  const categoryField = (isHorizontal ? layer.yField : layer.xField) || ''
+  const valueField = (isHorizontal ? layer.xField : layer.yField) || ''
+
+  const categoryIsDiscreteTime = hasDiscreteTimeTrait(categoryField, columns)
+  const categoryEncoding: any = {
+    ...createFieldEncoding(categoryField, columns, {}),
+    ...getSortOrder(categoryField, columns, valueField),
+  }
+  if (categoryIsDiscreteTime) {
+    categoryEncoding.type = 'ordinal'
+    delete categoryEncoding.timeUnit
+    delete categoryEncoding.format
+  }
+
+  const valueEncoding = createFieldEncoding(
+    valueField,
+    columns,
+    {
+      axis: {
+        ...getFormatHint(valueField, columns),
+        ...(layer.yAxisOrient ? { orient: layer.yAxisOrient } : {}),
+      },
+    },
+    false,
+    { scale: isHorizontal ? options.scaleX : options.scaleY },
+  )
+
+  const encoding: any = isHorizontal
+    ? { y: categoryEncoding, x: valueEncoding }
+    : { x: categoryEncoding, y: valueEncoding }
+
+  // Colour: an explicit colorField wins; otherwise a constant datum per layer
+  // drives a shared scale, which is what gives a layered chart a legend that
+  // names its series rather than one legend per layer.
+  if (layer.colorField) {
+    encoding.color = createColorEncoding(
+      layer,
+      layer.colorField,
+      columns,
+      isMobile,
+      currentTheme,
+      options.hideLegend,
+      data,
+      // Only layer 0 declares selection params, so only it can condition on them.
+      layerIndex === 0 ? '' : null,
+    )
+  } else if (seriesLabel) {
+    encoding.color = {
+      datum: seriesLabel,
+      type: 'nominal',
+      ...(options.hideLegend ? { legend: null } : { legend: { title: null } }),
+    }
+  }
+
+  if (layer.sizeField) {
+    encoding.size = createSizeEncoding(layer.sizeField, columns, isMobile, options.hideLegend)
+  }
+
+  if (tooltipFields.length) {
+    encoding.tooltip = tooltipFields
+  }
+
+  const spec: any = {
+    mark: layerMark(layer, currentTheme, Boolean(seriesLabel)),
+    encoding,
+  }
+
+  if (layer.annotationField && columns.get(layer.annotationField)) {
+    // Annotations ride along as a sibling text mark rather than mutating this
+    // layer, so the caller can splice both into the top-level layer array.
+    spec.__annotationLayer = {
+      mark: { type: 'text', align: 'left', baseline: 'middle', dx: 5, fontSize: 8 },
+      encoding: {
+        ...(isHorizontal
+          ? { y: categoryEncoding, x: valueEncoding }
+          : { x: categoryEncoding, y: valueEncoding }),
+        text: { field: layer.annotationField, type: 'nominal' },
+        color: { value: currentTheme === 'light' ? '#333333' : '#dddddd' },
+      },
+    }
+  }
+
+  // Suffix is unused for layers with no params today, but reserved so the
+  // interactive layer-0 builders and these stay on one naming scheme.
+  void suffix
+
+  return spec
+}
+
+/**
+ * Build the rule (and optional label) marks for a `place hline|vline` entry.
+ * Ported from pytrilogy's `AltairRenderer._render_placement`.
+ */
+export const createPlacementLayers = (
+  placement: NonNullable<ChartConfig['placements']>[number],
+  currentTheme: 'light' | 'dark' | '',
+): any[] => {
+  const isHline = placement.kind === 'hline'
+  const datumKey = isHline ? 'y' : 'x'
+  const otherKey = isHline ? 'x' : 'y'
+  const color = currentTheme === 'light' ? '#64748b' : '#94a3b8'
+
+  const layers: any[] = [
+    {
+      mark: { type: 'rule', color, strokeDash: [4, 4] },
+      encoding: { [datumKey]: { datum: placement.value } },
+    },
+  ]
+
+  if (placement.label) {
+    layers.push({
+      mark: {
+        type: 'text',
+        align: 'left',
+        baseline: isHline ? 'bottom' : 'top',
+        dx: 4,
+        dy: isHline ? -4 : 0,
+        fontSize: 11,
+        color,
+      },
+      encoding: {
+        [datumKey]: { datum: placement.value },
+        [otherKey]: { value: 4 },
+        text: { value: placement.label },
+      },
+    })
+  }
+
+  return layers
+}

--- a/lib/dashboards/spec.ts
+++ b/lib/dashboards/spec.ts
@@ -21,6 +21,15 @@ import { createBeeSwarmSpec } from './beeSwarmSpec'
 import { TRELLIS_ELIGIBLE, NO_AXES_CHARTS } from './constants'
 import { toJsonSafeRows, toJsonSafeValue } from '../utility/jsonSerialization'
 
+import {
+  normalizeChartConfig,
+  createLayerMarkSpec,
+  createPlacementLayers,
+  resolveLayerYScale,
+  layerSeriesLabel,
+  deriveChartTitle,
+} from './layerSpec'
+
 const generateTooltipFields = (config: ChartConfig, columns: Map<string, ResultColumn>): any[] => {
   const fields: any[] = []
 
@@ -102,7 +111,7 @@ const createBoxplotSpec = (
 import { compile } from 'vega-lite'
 export const generateVegaSpec = (
   data: readonly Row[] | null,
-  config: ChartConfig,
+  inputConfig: ChartConfig,
   columns: Map<string, ResultColumn>,
   chartSelection: Object[] | null,
   isMobile: boolean = false,
@@ -111,6 +120,24 @@ export const generateVegaSpec = (
   containerHeight: number = 400,
   containerWidth: number = 600,
 ) => {
+  // A config with sub-layers renders as a Vega-Lite layer array; an ordinary
+  // config resolves to exactly one layer and takes the path it always has.
+  // `config` below is layer 0 -- the interactive layer -- which for a
+  // single-layer chart is the input config itself.
+  const { root, layers } = normalizeChartConfig(inputConfig)
+  const config = layers[0]
+  const isLayered = layers.length > 1 || Boolean(root.placements?.length)
+
+  // Vega-Lite forbids facet channels inside a layered spec. Surface that rather
+  // than silently dropping a layer, mirroring pytrilogy's own renderer.
+  if (isLayered && (root.trellisField || root.trellisRowField)) {
+    throw new Error('Trellis roles cannot be combined with multiple layers or reference lines.')
+  }
+
+  // A series legend names the layers, but only when no layer drives colour from
+  // a field of its own -- two colour scales in one spec produce two legends.
+  const useSeriesLegend = layers.length > 1 && !layers.some((layer) => layer.colorField)
+
   let intChart: { [key: string]: string | number | Array<any> }[] = chartSelection
     ? (chartSelection.map((x) => toJsonSafeValue(toRaw(x))) as {
         [key: string]: string | number | Array<any>
@@ -190,20 +217,26 @@ export const generateVegaSpec = (
 
   // Set up color encoding
   let encoding: any = {}
-  encoding.color = createColorEncoding(
-    config,
-    !['heatmap'].includes(config.chartType) ? config.colorField : undefined,
-    columns,
-    isMobile,
-    currentTheme,
-    config.hideLegend,
-    localData,
-  )
+  encoding.color = useSeriesLegend
+    ? {
+        datum: layerSeriesLabel(config, columns, 0),
+        type: 'nominal',
+        ...(root.hideLegend ? { legend: null } : { legend: { title: null } }),
+      }
+    : createColorEncoding(
+        config,
+        !['heatmap'].includes(config.chartType) ? config.colorField : undefined,
+        columns,
+        isMobile,
+        currentTheme,
+        config.hideLegend,
+        localData,
+      )
 
   const tooltipFields = generateTooltipFields(config, columns)
 
   // Generate chart specification based on chart type
-  let chartSpec = {}
+  let chartSpec: any = {}
 
   switch (config.chartType) {
     case 'bar':
@@ -321,6 +354,46 @@ export const generateVegaSpec = (
       break
   }
 
+  // Stitch the remaining layers on top of layer 0. Layer 0 keeps its full
+  // per-type builder -- params, brush scaffolding and all -- so every existing
+  // interaction keeps working; layers 1..n are plain marks with suffixed param
+  // names and no selections of their own.
+  if (isLayered) {
+    const extraLayers: any[] = []
+
+    for (let i = 1; i < layers.length; i++) {
+      const layer = layers[i]
+      const layerSpec = createLayerMarkSpec(
+        layer,
+        columns,
+        generateTooltipFields(layer, columns),
+        localData,
+        {
+          layerIndex: i,
+          currentTheme,
+          isMobile,
+          seriesLabel: useSeriesLegend ? layerSeriesLabel(layer, columns, i) : undefined,
+          hideLegend: root.hideLegend,
+          scaleX: root.scaleX,
+          scaleY: root.scaleY,
+        },
+      )
+      const annotation = layerSpec.__annotationLayer
+      delete layerSpec.__annotationLayer
+      extraLayers.push(layerSpec)
+      if (annotation) extraLayers.push(annotation)
+    }
+
+    for (const placement of root.placements || []) {
+      extraLayers.push(...createPlacementLayers(placement, currentTheme))
+    }
+
+    // `chartSpec` is layer 0. If its builder already produced a layer array,
+    // keep it as one nested entry rather than flattening -- its sub-layers are
+    // a base/brush pair that must stay grouped.
+    chartSpec = { layer: [chartSpec, ...extraLayers] }
+  }
+
   // Apply chart spec to main spec
   const hasTrellis =
     (config.trellisField || config.trellisRowField) && TRELLIS_ELIGIBLE.includes(config.chartType)
@@ -330,7 +403,12 @@ export const generateVegaSpec = (
     spec = { ...spec, ...chartSpec }
   }
 
-  if (config.yField2 && !config.linkY2) {
+  if (isLayered) {
+    const yResolve = resolveLayerYScale(root, layers, columns)
+    if (yResolve === 'independent') {
+      spec.resolve = { ...spec.resolve, scale: { ...spec.resolve?.scale, y: 'independent' } }
+    }
+  } else if (config.yField2 && !config.linkY2) {
     spec.resolve = {
       scale: {
         y: 'independent',
@@ -347,12 +425,19 @@ export const generateVegaSpec = (
       stroke: null,
     },
   }
-  if (config.showTitle && title) {
-    spec.title = {
-      text: title,
-      anchor: 'start',
-      offset: 12,
-      color: currentTheme === 'dark' ? '#FFFFFF' : '#000000',
+  // `showTitle` means "show a title", not "show the title someone handed me":
+  // an explicit one wins, and otherwise we derive it from the chart's own
+  // fields. Without this, `set show_title` on a Trilogy chart statement did
+  // nothing in the editor, which never supplies a `chartTitle`.
+  if (root.showTitle || config.showTitle) {
+    const resolvedTitle = title || deriveChartTitle(layers, columns)
+    if (resolvedTitle) {
+      spec.title = {
+        text: resolvedTitle,
+        anchor: 'start',
+        offset: 12,
+        color: currentTheme === 'dark' ? '#FFFFFF' : '#000000',
+      }
     }
   }
 
@@ -415,8 +500,10 @@ export const generateVegaSpec = (
     }
   }
 
-  // Compile point charts to Vega after faceting is applied
-  if (config.chartType === 'point') {
+  // Compile point charts to Vega after faceting is applied. In a layered spec
+  // this is a property of any layer being a point layer, and the compile has to
+  // happen once at the top level rather than per layer.
+  if (layers.some((layer) => layer.chartType === 'point')) {
     const customLabelTransform = {
       type: 'label',
       anchor: ['right', 'top', 'bottom', 'left'],

--- a/lib/editors/results.test.ts
+++ b/lib/editors/results.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { DateTime } from 'luxon'
-import { Results, ColumnType } from './results'
+import { Results, ColumnType, migrateChartConfig } from './results'
 import type { ResultColumn } from './results'
 
 describe('Results serialization round-trip', () => {
@@ -58,5 +58,28 @@ describe('Results serialization round-trip', () => {
     const row = restored.data[0] as Record<string, any>
     expect(DateTime.isDateTime(row.ts)).toBe(true)
     expect(row.ts.toISO()).toBe('2024-06-01T00:00:00.000Z')
+  })
+})
+
+describe('migrateChartConfig with layers', () => {
+  it('migrates deprecated chart types inside sub-layers', () => {
+    const migrated = migrateChartConfig({
+      chartType: 'bar',
+      layers: [
+        { chartType: 'bar', xField: 'a', yField: 'b' },
+        { chartType: 'usa-map' as any, geoField: 'state' },
+      ],
+    })
+
+    expect(migrated?.layers?.[1].chartType).toBe('geo-map')
+    expect(migrated?.layers?.[0].chartType).toBe('bar')
+  })
+
+  it('returns the same object when nothing needs migrating', () => {
+    const config = {
+      chartType: 'bar' as const,
+      layers: [{ chartType: 'line' as const, xField: 'a', yField: 'b' }],
+    }
+    expect(migrateChartConfig(config)).toBe(config)
   })
 })

--- a/lib/editors/results.ts
+++ b/lib/editors/results.ts
@@ -82,6 +82,13 @@ export type chartTypes =
   | 'treemap'
   | 'beeswarm'
 
+/** A `place hline|vline at <value> [as <label>]` reference line. */
+export interface ChartPlacement {
+  kind: 'hline' | 'vline'
+  value: string | number
+  label?: string
+}
+
 // Chart configuration interface
 export interface ChartConfig {
   chartType: chartTypes
@@ -100,6 +107,52 @@ export interface ChartConfig {
   scaleX?: 'linear' | 'log' | 'sqrt'
   scaleY?: 'linear' | 'log' | 'sqrt'
   linkY2?: boolean
+
+  /**
+   * Sub-layers, each a chart config in its own right. Present and non-empty
+   * means this config is a *container*: its own field bindings are ignored and
+   * only its statement-level settings (title, legend, scales, placements)
+   * apply. Absent -- the overwhelmingly common case -- means this is a plain
+   * single-layer config and nothing about its handling changes.
+   */
+  layers?: ChartConfig[]
+
+  /** Reference lines drawn over every layer. Container-level only. */
+  placements?: ChartPlacement[]
+
+  /**
+   * Display name for this layer in the series legend. Set from a chart
+   * statement's `as` alias; ignored on a container.
+   */
+  layerLabel?: string
+
+  /**
+   * Force shared (`true`) or independent (`false`) y scales across layers.
+   * Unset lets the renderer decide from the layers' format hints.
+   */
+  linkLayerY?: boolean
+
+  /** Which side this layer's value axis is drawn on. Layer-level. */
+  yAxisOrient?: 'left' | 'right'
+}
+
+/** Field keys that bind a layer to data, as opposed to statement-level settings. */
+export const LAYER_FIELD_KEYS = [
+  'xField',
+  'yField',
+  'yField2',
+  'colorField',
+  'sizeField',
+  'groupField',
+  'trellisField',
+  'trellisRowField',
+  'geoField',
+  'annotationField',
+] as const
+
+/** True when this config delegates its rendering to sub-layers. */
+export function isLayeredConfig(config: ChartConfig | undefined | null): boolean {
+  return Boolean(config?.layers && config.layers.length > 0)
 }
 
 // Migration map for deprecated chart type names
@@ -109,8 +162,13 @@ const CHART_TYPE_MIGRATIONS: Record<string, chartTypes> = {
 
 /**
  * Migrates a ChartConfig from older versions to the current schema.
- * Handles renamed chart types (e.g., 'usa-map' -> 'geo-map').
+ * Handles renamed chart types (e.g., 'usa-map' -> 'geo-map'), recursing into
+ * sub-layers so a nested config gets the same treatment as a flat one.
  * Returns a new config object if migration was needed, or the original if not.
+ *
+ * Note this is *not* where `yField2` becomes a second layer: that fold happens
+ * at render time in `normalizeChartConfig`, because this function only runs on
+ * dashboard item data and would miss the editor, LLM and statement paths.
  */
 export function migrateChartConfig(
   config: ChartConfig | undefined | null,
@@ -118,14 +176,25 @@ export function migrateChartConfig(
   if (!config) return undefined
 
   const migratedType = CHART_TYPE_MIGRATIONS[config.chartType]
-  if (migratedType) {
-    return {
-      ...config,
-      chartType: migratedType,
+
+  let migratedLayers: ChartConfig[] | undefined
+  if (config.layers?.length) {
+    const next = config.layers.map((layer) => migrateChartConfig(layer) as ChartConfig)
+    // Only allocate a new array if a layer actually changed.
+    if (next.some((layer, i) => layer !== config.layers![i])) {
+      migratedLayers = next
     }
   }
 
-  return config
+  if (!migratedType && !migratedLayers) {
+    return config
+  }
+
+  return {
+    ...config,
+    ...(migratedType ? { chartType: migratedType } : {}),
+    ...(migratedLayers ? { layers: migratedLayers } : {}),
+  }
 }
 
 export class Results implements ResultsInterface {


### PR DESCRIPTION
Frontend half of rendering Trilogy `chart layer ... layer ...` statements. Makes `ChartConfig` recursive and teaches `generateVegaSpec` to stitch layers into a Vega-Lite `layer` array. The wire format (per-layer columns) and multi-dataset execution follow in phase B — **no chart statement renders two layers yet.**

Follow-on to #250. Design record in `docs/chart-layering-handoff.md` (the brief) and `docs/chart-layering-audit.md` (the audit that scoped this, including what the brief got wrong).

## The shape

`ChartConfig` grows an optional `layers: ChartConfig[]`. Non-empty means the config is a *container*: root bindings ignored, statement-level settings only. **A config with no `layers` key behaves exactly as before**, so nothing persisted has to migrate.

New `lib/dashboards/layerSpec.ts`:

| | |
|---|---|
| `normalizeChartConfig` | any config → `{root, layers[]}` |
| `createLayerMarkSpec` | one Vega-Lite unit spec per layer |
| `createPlacementLayers` | `place hline/vline`, ported from pytrilogy's `_render_placement` |
| `resolveLayerYScale` | shared vs independent axes, inferred from format hints |
| `deriveChartTitle` | mirrors `AltairRenderer._statement_title` |

## Decisions worth reviewing

**Layer 0 is the interactive layer.** It keeps its full per-type builder and the unsuffixed `highlight`/`select`/`brush` param names, so `setupEventListeners`, the brush filter transforms and cross-filtering keep working untouched. Layers 1..n are plain marks with no selections — which makes duplicate Vega param names *structurally impossible* rather than merely avoided. This is also the concrete form of "brushing applies to layer 0 only." The generic suffix helpers are in place for when a layer past 0 needs interactivity.

**`yField2` folds at render time, not in persistence.** `migrateChartConfig` has only two callsites, both on dashboard item data — folding there would convert one path out of four. Doing it in `normalizeChartConfig` means `yField2` stays a valid *authoring* shape (controls panel and LLM schema keep it) while layering becomes the *rendering* model. That lets `barChartSpec`'s duplicated `secondaryLineLayer` be deleted with no stored config touched. `line`/`area` keep owning `yField2` — their secondary series is a brush-linked base/filtered pair the generic machinery doesn't reproduce, and folding it would be a visible regression.

**Layers aren't gated on `determineEligibleChartTypes`.** That's an auto-suggestion heuristic for picking a chart type from data shape; it rejects `layer bar` + `layer line` over a categorical x, which is the language's own motivating example. Layers are validated on layerability and field existence instead.

**Non-layerable types are an allowlist, not a limit.** `beeswarm` emits a raw Vega spec; `headline`/`tree` own their top-level chrome; `geo-map` carries a projection. Excluded from v1 with an explicit error rather than a dropped layer.

## The main regression risk, fixed

`validateConfigFields`, `validateAndResetConfig` and `validateChartConfigForData` all used to see a container config with no root field bindings, report it invalid, and **persist a flattened replacement** — `dashboardToolExecutor` writes `suggestedConfig` back via `updateItemChartConfig`. All three are now layer-aware, with tests asserting no `onChartConfigChange` fires for a valid layered config.

## `set show_title` now does something

`showTitle` meant "show the title someone handed me", and only dashboards pass a `chartTitle` — so `set show_title` on a chart statement rendered nothing in the editor. It now means "show a title": explicit wins, otherwise derived from the chart's own fields using pytrilogy's precedence, so the studio and `trilogy` title the same statement identically.

`determineDefaultConfig`'s `showTitle` default flips **true → false** to keep titles opt-in now that they actually render — otherwise every auto-configured editor chart would gain one.

## Testing

1574 unit tests pass; `vue-tsc -b` clean. 34 new, including `vega-lite` `compile()` guards for param collisions (shape assertions wouldn't catch a duplicate signal name) and no-flattening guards on all three validators.

No Playwright yet: the only user-reachable path this changes is the dual-axis bar chart, so an e2e here would test the migration rather than the feature. The e2e that earns its keep is the two-layer chart statement — a phase B artifact.

## Known follow-ups (phase B)

- Cross-filter on a true layered config no-ops: `VegaLiteChart` hands the interaction handlers `internalConfig` (the container). Harmless today — the `yField2` path passes the flat config — but phase B needs them pointed at `layers[0]`.
- The LLM can't author layers: `chartConfigSchema` is untouched. Deliberate — it's a one-time prompt-cache bust plus a `toolRegistry.test.ts` golden update, better done once the shape settles.
- `generateVegaSpec` should move to an options object when it takes per-layer `{data, columns}`; nine positional params is already past the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJf61x5bHLCACcw5tip9fZ
