### PR TITLE
[Feat] Chat docs tools, disabledTools/extraTools options, DataTable showControls, scoped icon masks (0.1.24)

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -112,6 +112,34 @@ instead of guessing at syntax, and the system prompt tells it to. `open_document
 same pack; it needs app navigation and reports itself unavailable without it, so an embedding
 host typically withholds it with `disabledTools` (below).
 
+## Adding Host Tools to a Chat
+
+`useTrilogyChat` (and `useChatWithTools` for persistent chats) also takes `extraTools`: tools the
+host application defines, each a definition for the model plus the function that runs it. They
+are sent after the built-ins and ahead of `return_to_user`, and a call to one runs the host's
+executor instead of the library's registry. A host tool may not reuse a built-in name.
+
+```ts
+const chat = useTrilogyChat({
+  dataConnectionName: 'my-database',
+  extraTools: [
+    {
+      definition: {
+        name: 'show_in_view',
+        description: 'Open the launches map filtered to a launch site.',
+        input_schema: { type: 'object', properties: { site: { type: 'string' } }, required: ['site'] },
+      },
+      execute: async ({ site }) => {
+        router.push({ name: 'rockets', query: { site } })
+        return { success: true, message: `Opened the launches map for ${site}.` }
+      },
+    },
+  ],
+})
+```
+
+`customTools` remains the standalone-mode (no chat store) equivalent.
+
 ## Withholding Chat Tools
 
 `useTrilogyChat` (and `useChatWithTools` for persistent chats) takes `disabledTools`, a list of

--- a/lib/README.md
+++ b/lib/README.md
@@ -104,6 +104,24 @@ the host app's `public/` assets or another static host. Importing DuckDB files w
 multiple Vite build graphs can still emit duplicate hashed files even when they resolve to the same
 source package.
 
+## Withholding Chat Tools
+
+`useTrilogyChat` (and `useChatWithTools` for persistent chats) takes `disabledTools`, a list of
+chat tool names — or a ref/getter for one — to keep out of the conversation. The tools are removed
+from the request and the prompt guidance that asks for them is dropped, so the model is never told
+to call something it cannot see. Use it when a host surface makes a tool pointless: a layout with
+no artifact panel has nothing for `reorder_artifacts` to reorder.
+
+```ts
+const chat = useTrilogyChat({
+  dataConnectionName: 'my-database',
+  disabledTools: () => (isNarrowScreen.value ? ['reorder_artifacts'] : []),
+})
+```
+
+The toolset is part of the provider's prompt-cache prefix, so keep the list stable within a
+conversation where you can; each change costs one cache miss.
+
 ## Styling Prerequisites
 
 The package stylesheet (`@trilogy-data/trilogy-studio-components/style.css`) carries the

--- a/lib/README.md
+++ b/lib/README.md
@@ -104,6 +104,14 @@ the host app's `public/` assets or another static host. Importing DuckDB files w
 multiple Vite build graphs can still emit duplicate hashed files even when they resolve to the same
 source package.
 
+## Chat Documentation Tools
+
+The chat toolset carries the docs pack: `search_docs` and `read_doc` let the agent look up Trilogy
+idioms (window functions, date handling, filtering on aggregates) from the in-app documentation
+instead of guessing at syntax, and the system prompt tells it to. `open_documentation` is in the
+same pack; it needs app navigation and reports itself unavailable without it, so an embedding
+host typically withholds it with `disabledTools` (below).
+
 ## Withholding Chat Tools
 
 `useTrilogyChat` (and `useChatWithTools` for persistent chats) takes `disabledTools`, a list of

--- a/lib/README.md
+++ b/lib/README.md
@@ -104,6 +104,26 @@ the host app's `public/` assets or another static host. Importing DuckDB files w
 multiple Vite build graphs can still emit duplicate hashed files even when they resolve to the same
 source package.
 
+## Styling Prerequisites
+
+The package stylesheet (`@trilogy-data/trilogy-studio-components/style.css`) carries the
+components' own styles only. Two things come from the host page:
+
+- **Tabulator's base stylesheet.** `DataTable` is built on
+  [Tabulator](https://tabulator.info/) and relies on its layout rules (nowrap headers, inline
+  column and cell widths). Import one of Tabulator's sheets before the package stylesheet, e.g.
+  `import 'tabulator-tables/dist/css/tabulator.min.css'`, and put any theme overrides after it.
+  Without it the table renders with no layout at all — header columns wrap and cells lose their
+  widths.
+- **Icons beyond the registered set.** The package registers the Material Design Icons it uses
+  itself as SVG masks (`lib/icons/registerMdiIcons.ts`), so those `mdi-*` classes need no icon
+  font. A class outside that set is left untouched and renders with whatever the host provides,
+  typically the `@mdi/font` webfont; with no font loaded it renders as nothing.
+
+`DataTable` also takes `showControls` (default `true`). Set it `false` to drop the floating
+copy/download buttons and call `copyToClipboard()` / `downloadData()` on the component through a
+template ref from controls of your own.
+
 ## Embedding Themes
 
 Embedded consumers can now provide theme information without wiring the full Studio `userSettingsStore`.

--- a/lib/components/DataTable.test.ts
+++ b/lib/components/DataTable.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import DataTable from './DataTable.vue'
+import { ColumnType, type ResultColumn, type Row } from '../editors/results'
+
+// Tabulator needs a laid-out element; jsdom gives every element a zero
+// offsetWidth, so create() stays pending and the table is never built. That
+// is fine here: these tests are about the component's own chrome.
+
+const headers = new Map<string, ResultColumn>([
+  ['name', { name: 'name', type: ColumnType.STRING, description: '' }],
+  ['launches', { name: 'launches', type: ColumnType.INTEGER, description: '' }],
+])
+const results: Row[] = [
+  { name: 'Falcon 9', launches: 100 },
+  { name: 'Electron', launches: 12 },
+]
+
+function mountTable(props: Record<string, unknown> = {}) {
+  return mount(DataTable, {
+    props: { headers, results, ...props },
+    global: { provide: { userSettingsStore: null } },
+  })
+}
+
+describe('DataTable controls', () => {
+  it('renders the floating copy/download buttons by default', () => {
+    const wrapper = mountTable()
+    expect(wrapper.find('.controls-toggle').exists()).toBe(true)
+    expect(wrapper.findAll('.control-btn')).toHaveLength(2)
+  })
+
+  it('omits the floating buttons when showControls is false', () => {
+    const wrapper = mountTable({ showControls: false })
+    expect(wrapper.find('.controls-toggle').exists()).toBe(false)
+    expect(wrapper.find('.control-btn').exists()).toBe(false)
+  })
+
+  /*
+    A host that hides the floating buttons renders its own affordances and
+    drives the table through a template ref, so the two actions are part of the
+    component's public surface. Both bail out without a Tabulator instance
+    rather than throwing, which is what a host hits if it fires one before the
+    table has laid out.
+  */
+  it('exposes copyToClipboard and downloadData for host-rendered controls', async () => {
+    const wrapper = mountTable({ showControls: false })
+    const vm = wrapper.vm as unknown as {
+      copyToClipboard: () => Promise<void>
+      downloadData: () => void
+    }
+    expect(typeof vm.copyToClipboard).toBe('function')
+    expect(typeof vm.downloadData).toBe('function')
+
+    const writeText = vi.fn()
+    Object.assign(navigator, { clipboard: { writeText } })
+    await expect(vm.copyToClipboard()).resolves.toBeUndefined()
+    expect(() => vm.downloadData()).not.toThrow()
+    expect(writeText).not.toHaveBeenCalled()
+  })
+})

--- a/lib/components/DataTable.vue
+++ b/lib/components/DataTable.vue
@@ -8,7 +8,11 @@
   >
     <div class="table-container" :class="{ 'table-container-flush': flushChrome }">
       <!-- Minimal floating action buttons -->
-      <div class="controls-toggle" :class="{ 'controls-visible': controlsVisible }">
+      <div
+        v-if="showControls"
+        class="controls-toggle"
+        :class="{ 'controls-visible': controlsVisible }"
+      >
         <button
           class="control-btn"
           @click="copyToClipboard"
@@ -459,6 +463,16 @@ export default {
     flushChrome: {
       type: Boolean,
       default: false,
+    },
+    /**
+     * Render the floating copy/download buttons over the table. A host that
+     * wants those actions somewhere else (a card header, a toolbar) sets this
+     * false and calls `copyToClipboard()` / `downloadData()` on the component
+     * through a template ref; both are public for that purpose.
+     */
+    showControls: {
+      type: Boolean,
+      default: true,
     },
   },
   setup() {

--- a/lib/composables/useChatWithTools.ts
+++ b/lib/composables/useChatWithTools.ts
@@ -1,5 +1,5 @@
-import { ref, computed, watch } from 'vue'
-import type { Ref, ComputedRef } from 'vue'
+import { ref, computed, watch, toValue } from 'vue'
+import type { Ref, ComputedRef, MaybeRefOrGetter } from 'vue'
 import type { LLMConnectionStoreType } from '../stores/llmStore'
 import type { ConnectionStoreType } from '../stores/connectionStore'
 import type QueryExecutionService from '../stores/queryExecutionService'
@@ -60,6 +60,16 @@ export interface UseChatWithToolsOptions {
    * Return a string result to feed back to the LLM.
    */
   onCustomToolCall?: (toolName: string, toolInput: Record<string, unknown>) => Promise<string>
+
+  /**
+   * Chat tools to withhold from the model, by name, with their prompt guidance
+   * (persistent chats only). For a host whose surface makes a tool pointless:
+   * a layout with no artifact panel has nothing for `reorder_artifacts` to
+   * reorder. Accepts a ref or getter and is read at send time, but keep it
+   * stable within a conversation — the toolset is part of the provider's
+   * prompt-cache prefix, so each change costs a cache miss.
+   */
+  disabledTools?: MaybeRefOrGetter<readonly string[]>
 }
 
 export interface UseChatWithToolsReturn {
@@ -107,6 +117,7 @@ export function useChatWithTools(options: UseChatWithToolsOptions): UseChatWithT
     dataConnectionName: initialDataConnectionName,
     initialTitle = 'Chat',
     customTools,
+    disabledTools,
     onCustomToolCall,
   } = options
 
@@ -364,6 +375,7 @@ export function useChatWithTools(options: UseChatWithToolsOptions): UseChatWithT
       activeImports: activeImportsForChat.value,
       availableImportsForConnection: availableImportsForChat.value,
       isDataConnectionActive,
+      disabledTools: toValue(disabledTools),
     })
   })
 
@@ -449,6 +461,7 @@ export function useChatWithTools(options: UseChatWithToolsOptions): UseChatWithT
         },
         {
           onSymbolsRefresh: refreshChatSymbols,
+          disabledTools: toValue(disabledTools),
         },
       )
     }

--- a/lib/composables/useChatWithTools.ts
+++ b/lib/composables/useChatWithTools.ts
@@ -8,7 +8,7 @@ import type { EditorStoreType } from '../stores/editorStore'
 import type { NavigationStore } from '../stores/useScreenNavigation'
 import { KeySeparator } from '../data/constants'
 import type { ChatMessage, ChatArtifact, ChatImport } from '../chats/chat'
-import { buildChatAgentSystemPrompt } from '../llm/chatAgentPrompt'
+import { buildChatAgentSystemPrompt, type HostChatTool } from '../llm/chatAgentPrompt'
 import { completionItemsToConcepts } from '../llm/editorRefinementTools'
 import type { ModelConceptInput } from '../llm/data/models'
 import type { ContentInput, CompletionItem } from '../stores/resolver'
@@ -70,6 +70,14 @@ export interface UseChatWithToolsOptions {
    * prompt-cache prefix, so each change costs a cache miss.
    */
   disabledTools?: MaybeRefOrGetter<readonly string[]>
+
+  /**
+   * Host-defined tools for persistent chats: a definition for the model plus
+   * the function that runs it. The counterpart of `customTools`, which only
+   * the standalone path honours. Read at send time like `disabledTools`, with
+   * the same prompt-cache caveat.
+   */
+  extraTools?: MaybeRefOrGetter<readonly HostChatTool[]>
 }
 
 export interface UseChatWithToolsReturn {
@@ -118,6 +126,7 @@ export function useChatWithTools(options: UseChatWithToolsOptions): UseChatWithT
     initialTitle = 'Chat',
     customTools,
     disabledTools,
+    extraTools,
     onCustomToolCall,
   } = options
 
@@ -462,6 +471,7 @@ export function useChatWithTools(options: UseChatWithToolsOptions): UseChatWithT
         {
           onSymbolsRefresh: refreshChatSymbols,
           disabledTools: toValue(disabledTools),
+          extraTools: toValue(extraTools),
         },
       )
     }

--- a/lib/composables/useTrilogyChat.ts
+++ b/lib/composables/useTrilogyChat.ts
@@ -1,6 +1,7 @@
 import { useTrilogyCore, type TrilogyCoreOptions } from './useTrilogyCore'
 import { useChatWithTools, type UseChatWithToolsReturn } from './useChatWithTools'
 import type { NavigationStore } from '../stores/useScreenNavigation'
+import type { MaybeRefOrGetter } from 'vue'
 
 export interface TrilogyChatOptions extends TrilogyCoreOptions {
   /**
@@ -31,6 +32,11 @@ export interface TrilogyChatOptions extends TrilogyCoreOptions {
    * If not provided, one will be created internally.
    */
   navigationStore?: NavigationStore | null
+  /**
+   * Chat tools to withhold from the model, by name, along with the prompt
+   * guidance that asks for them. See `UseChatWithToolsOptions.disabledTools`.
+   */
+  disabledTools?: MaybeRefOrGetter<readonly string[]>
 }
 
 /**
@@ -73,6 +79,7 @@ export function useTrilogyChat(options: TrilogyChatOptions = {}): UseChatWithToo
     persistChat = true,
     onTitleUpdate,
     navigationStore: providedNavigationStore,
+    disabledTools,
   } = options
 
   // Initialize all core stores and services
@@ -95,6 +102,7 @@ export function useTrilogyChat(options: TrilogyChatOptions = {}): UseChatWithToo
     dataConnectionName,
     initialTitle,
     onTitleUpdate,
+    disabledTools,
   })
 }
 

--- a/lib/composables/useTrilogyChat.ts
+++ b/lib/composables/useTrilogyChat.ts
@@ -2,6 +2,7 @@ import { useTrilogyCore, type TrilogyCoreOptions } from './useTrilogyCore'
 import { useChatWithTools, type UseChatWithToolsReturn } from './useChatWithTools'
 import type { NavigationStore } from '../stores/useScreenNavigation'
 import type { MaybeRefOrGetter } from 'vue'
+import type { HostChatTool } from '../llm/chatAgentPrompt'
 
 export interface TrilogyChatOptions extends TrilogyCoreOptions {
   /**
@@ -37,6 +38,11 @@ export interface TrilogyChatOptions extends TrilogyCoreOptions {
    * guidance that asks for them. See `UseChatWithToolsOptions.disabledTools`.
    */
   disabledTools?: MaybeRefOrGetter<readonly string[]>
+  /**
+   * Host-defined tools added to the conversation. See
+   * `UseChatWithToolsOptions.extraTools`.
+   */
+  extraTools?: MaybeRefOrGetter<readonly HostChatTool[]>
 }
 
 /**
@@ -80,6 +86,7 @@ export function useTrilogyChat(options: TrilogyChatOptions = {}): UseChatWithToo
     onTitleUpdate,
     navigationStore: providedNavigationStore,
     disabledTools,
+    extraTools,
   } = options
 
   // Initialize all core stores and services
@@ -103,6 +110,7 @@ export function useTrilogyChat(options: TrilogyChatOptions = {}): UseChatWithToo
     initialTitle,
     onTitleUpdate,
     disabledTools,
+    extraTools,
   })
 }
 

--- a/lib/icons/registerMdiIcons.test.ts
+++ b/lib/icons/registerMdiIcons.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, resolve } from 'node:path'
-import { ICON_CLASS_NAMES, resolveMdiIconPath } from './registerMdiIcons'
+import { ICON_CLASS_NAMES, buildMdiStylesheet, resolveMdiIconPath } from './registerMdiIcons'
 
 /**
  * Icons are an explicit allowlist: a class only renders if it appears in
- * ICON_CLASS_NAMES *and* ICON_PATH_MAP. An unregistered one fails silently and
- * badly — `.mdi::before` still paints a 1em box filled with currentColor, just
- * with no mask — so the UI shows a solid black square rather than nothing at
- * all. That reads as a styling quirk, not a missing registration, which is why
- * it needs a test rather than review attention.
+ * ICON_CLASS_NAMES *and* ICON_PATH_MAP. An unregistered one fails silently:
+ * this repo loads no icon font, so the element renders as nothing at all. That
+ * reads as a styling quirk, not a missing registration, which is why it needs
+ * a test rather than review attention.
  */
 
 const REPO_ROOT = resolve(__dirname, '../..')
@@ -77,6 +76,49 @@ describe('MDI icon registration', () => {
     // and produces the same filled square as an unregistered class.
     const missingPaths = ICON_CLASS_NAMES.filter((name) => !resolveMdiIconPath(name))
     expect(missingPaths).toEqual([])
+  })
+
+  /*
+    The stylesheet is appended to <head> at runtime, so it out-cascades any
+    icon font a host page loads. A bare `.mdi::before` rule therefore replaced
+    every host icon the registry did not know with a solid currentColor square;
+    the mask box must only ever apply to registered classes.
+  */
+  describe('generated stylesheet', () => {
+    const css = buildMdiStylesheet()
+    const maskBoxRules = css
+      .split('}')
+      .filter((rule) => rule.includes('background-color: currentColor'))
+      .map((rule) => rule.split('{')[0].trim())
+
+    it('scopes the mask box to registered icon classes', () => {
+      expect(maskBoxRules).toHaveLength(1)
+      const [selector] = maskBoxRules
+      expect(selector).not.toMatch(/(^|,)\s*\.mdi::before/)
+      expect(selector).toContain('.mdi:is(')
+      for (const name of ICON_CLASS_NAMES) {
+        expect(selector).toContain(`.${name}`)
+      }
+    })
+
+    it('does not paint a box for an unregistered class', () => {
+      // Every rule that could reach `.mdi-not-registered::before` must come
+      // from the base sizing/spin modifiers, none of which set content.
+      const reaching = css.split('}').filter((rule) => {
+        const selector = rule.split('{')[0]
+        return (
+          /(^|[\s,])\.mdi(\.mdi-spin|\.mdi-\d+px)?::before/.test(selector) &&
+          !selector.includes(':is(')
+        )
+      })
+      expect(reaching.some((rule) => rule.includes('content:'))).toBe(false)
+    })
+
+    it('emits a mask image for every registered icon', () => {
+      for (const name of ICON_CLASS_NAMES) {
+        expect(css).toContain(`.${name}::before {`)
+      }
+    })
   })
 
   it('resolves the icon class out of a full class attribute', () => {

--- a/lib/icons/registerMdiIcons.ts
+++ b/lib/icons/registerMdiIcons.ts
@@ -434,6 +434,22 @@ function toSvgDataUrl(path: string): string {
   return `url("data:image/svg+xml,${encodeURIComponent(svg)}")`
 }
 
+/**
+ * Selector for the mask box, matching only the icons this module registers.
+ *
+ * It used to be a bare `.mdi::before`, which painted a 1em square of
+ * currentColor on *every* `.mdi` element, including classes the registry does
+ * not know. A host page that also loads the Material Design Icons webfont then
+ * saw its own icons (say `mdi-share-variant`) replaced by solid squares, since
+ * this stylesheet is appended at runtime and out-cascades the font's rules.
+ * Scoping the box to registered classes leaves an unregistered icon to whatever
+ * the host provides for it. Inside this repo that is still nothing, which is
+ * what the registration test guards.
+ */
+function registeredIconSelector(): string {
+  return `.mdi:is(${ICON_CLASS_NAMES.map((name) => `.${name}`).join(', ')})::before`
+}
+
 function buildBaseCss(): string {
   return `
 .mdi {
@@ -447,7 +463,7 @@ function buildBaseCss(): string {
   -moz-osx-font-smoothing: grayscale;
 }
 
-.mdi::before,
+${registeredIconSelector()},
 .mdi-set {
   content: "";
   display: inline-block;
@@ -528,6 +544,11 @@ function buildIconCss(): string {
   }).join('')
 }
 
+/** The full stylesheet `registerMdiIcons` injects. Exported for tests. */
+function buildMdiStylesheet(): string {
+  return buildBaseCss() + buildIconCss()
+}
+
 function registerMdiIcons(): void {
   if (typeof document === 'undefined') {
     return
@@ -539,7 +560,7 @@ function registerMdiIcons(): void {
 
   const style = document.createElement('style')
   style.id = STYLE_ELEMENT_ID
-  style.textContent = buildBaseCss() + buildIconCss()
+  style.textContent = buildMdiStylesheet()
   document.head.appendChild(style)
 }
 
@@ -560,4 +581,4 @@ function resolveMdiIconPath(classNames: Iterable<string> | string): string | nul
   return null
 }
 
-export { ICON_CLASS_NAMES, registerMdiIcons, resolveMdiIconPath }
+export { ICON_CLASS_NAMES, buildMdiStylesheet, registerMdiIcons, resolveMdiIconPath }

--- a/lib/llm/chatAgentPrompt.test.ts
+++ b/lib/llm/chatAgentPrompt.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { CHAT_TOOLS, buildChatAgentSystemPrompt, filterDisabledTools } from './chatAgentPrompt'
+
+const baseOptions = {
+  dataConnectionName: 'duckdb',
+  availableConnections: ['duckdb'],
+}
+
+describe('filterDisabledTools', () => {
+  it('returns the same array when nothing is disabled', () => {
+    // The shared registry's toolset identity is part of its cache contract.
+    expect(filterDisabledTools(CHAT_TOOLS, undefined)).toBe(CHAT_TOOLS)
+    expect(filterDisabledTools(CHAT_TOOLS, [])).toBe(CHAT_TOOLS)
+  })
+
+  it('drops only the named tools, in order', () => {
+    const names = filterDisabledTools(CHAT_TOOLS, ['reorder_artifacts']).map((t) => t.name)
+    expect(names).not.toContain('reorder_artifacts')
+    expect(names).toEqual(CHAT_TOOLS.map((t) => t.name).filter((n) => n !== 'reorder_artifacts'))
+  })
+})
+
+describe('buildChatAgentSystemPrompt disabledTools', () => {
+  it('keeps every artifact instruction when nothing is disabled', () => {
+    const prompt = buildChatAgentSystemPrompt(baseOptions)
+    expect(prompt).toContain('4. Reorder artifacts for maximum impact')
+    expect(prompt).toContain('5. The artifact panel should tell a coherent story')
+    expect(prompt).toContain('- Use hide_artifact to remove stale')
+  })
+
+  it('drops the guidance for a disabled tool and renumbers the curation steps', () => {
+    const prompt = buildChatAgentSystemPrompt({
+      ...baseOptions,
+      disabledTools: ['reorder_artifacts'],
+    })
+    expect(prompt).not.toContain('reorder_artifacts')
+    expect(prompt).not.toContain('Reorder artifacts')
+    // The step after the dropped one takes its number, so the list stays
+    // contiguous and the model is not told to look for a missing step 4.
+    expect(prompt).toContain('4. The artifact panel should tell a coherent story')
+    const curation = prompt.slice(
+      prompt.indexOf('ARTIFACT CURATION'),
+      prompt.indexOf('COMPLETING YOUR RESPONSE'),
+    )
+    expect(curation).not.toContain('5. ')
+    // Untouched guidance stays.
+    expect(prompt).toContain('1. Call list_artifacts')
+    expect(prompt).toContain('- Use hide_artifact to remove stale')
+  })
+
+  it('drops every line that asks for a disabled tool, wherever it appears', () => {
+    const prompt = buildChatAgentSystemPrompt({
+      ...baseOptions,
+      disabledTools: ['create_markdown'],
+    })
+    expect(prompt).not.toContain('create_markdown')
+    expect(prompt).not.toContain('template expressions')
+    expect(prompt).toContain('1. Call list_artifacts')
+  })
+
+  it('leaves the prompt byte-identical for an empty list', () => {
+    expect(buildChatAgentSystemPrompt({ ...baseOptions, disabledTools: [] })).toBe(
+      buildChatAgentSystemPrompt(baseOptions),
+    )
+  })
+})

--- a/lib/llm/chatAgentPrompt.test.ts
+++ b/lib/llm/chatAgentPrompt.test.ts
@@ -9,12 +9,13 @@ const baseOptions = {
 describe('filterDisabledTools', () => {
   it('returns the same array when nothing is disabled', () => {
     // The shared registry's toolset identity is part of its cache contract.
-    expect(filterDisabledTools(CHAT_TOOLS, undefined)).toBe(CHAT_TOOLS)
-    expect(filterDisabledTools(CHAT_TOOLS, [])).toBe(CHAT_TOOLS)
+    const tools = [...CHAT_TOOLS]
+    expect(filterDisabledTools(tools, undefined)).toBe(tools)
+    expect(filterDisabledTools(tools, [])).toBe(tools)
   })
 
   it('drops only the named tools, in order', () => {
-    const names = filterDisabledTools(CHAT_TOOLS, ['reorder_artifacts']).map((t) => t.name)
+    const names = filterDisabledTools([...CHAT_TOOLS], ['reorder_artifacts']).map((t) => t.name)
     expect(names).not.toContain('reorder_artifacts')
     expect(names).toEqual(CHAT_TOOLS.map((t) => t.name).filter((n) => n !== 'reorder_artifacts'))
   })

--- a/lib/llm/chatAgentPrompt.test.ts
+++ b/lib/llm/chatAgentPrompt.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { CHAT_TOOLS, buildChatAgentSystemPrompt, filterDisabledTools } from './chatAgentPrompt'
+import {
+  CHAT_TOOLS,
+  buildChatAgentSystemPrompt,
+  filterDisabledTools,
+  mergeExtraTools,
+  type HostChatTool,
+} from './chatAgentPrompt'
 
 const baseOptions = {
   dataConnectionName: 'duckdb',
@@ -76,5 +82,43 @@ describe('buildChatAgentSystemPrompt disabledTools', () => {
     expect(buildChatAgentSystemPrompt({ ...baseOptions, disabledTools: [] })).toBe(
       buildChatAgentSystemPrompt(baseOptions),
     )
+  })
+})
+
+describe('mergeExtraTools', () => {
+  const hostTool = (name: string): HostChatTool => ({
+    definition: {
+      name,
+      description: `host ${name}`,
+      input_schema: { type: 'object', properties: {} },
+    },
+    execute: async () => ({ success: true, message: 'ok' }),
+  })
+
+  it('returns the same array when there is nothing to add', () => {
+    const tools = [...CHAT_TOOLS]
+    expect(mergeExtraTools(tools, undefined)).toBe(tools)
+    expect(mergeExtraTools(tools, [])).toBe(tools)
+  })
+
+  it('inserts host tools after the built-ins and ahead of return_to_user', () => {
+    const names = mergeExtraTools([...CHAT_TOOLS], [hostTool('show_in_view')]).map((t) => t.name)
+    expect(names.at(-1)).toBe('return_to_user')
+    expect(names.at(-2)).toBe('show_in_view')
+    expect(names.slice(0, -2)).toEqual(
+      CHAT_TOOLS.map((t) => t.name).filter((n) => n !== 'return_to_user'),
+    )
+  })
+
+  it('appends when the toolset has no return_to_user', () => {
+    const names = mergeExtraTools([{ name: 'a' }], [hostTool('b')]).map((t) => t.name)
+    expect(names).toEqual(['a', 'b'])
+  })
+
+  it('refuses a host tool that shadows a built-in or repeats a name', () => {
+    expect(() => mergeExtraTools([...CHAT_TOOLS], [hostTool('run_trilogy_query')])).toThrow(
+      /shadows/,
+    )
+    expect(() => mergeExtraTools([...CHAT_TOOLS], [hostTool('x'), hostTool('x')])).toThrow(/twice/)
   })
 })

--- a/lib/llm/chatAgentPrompt.test.ts
+++ b/lib/llm/chatAgentPrompt.test.ts
@@ -58,6 +58,19 @@ describe('buildChatAgentSystemPrompt disabledTools', () => {
     expect(prompt).toContain('1. Call list_artifacts')
   })
 
+  it('drops the whole documentation section when both docs tools are disabled', () => {
+    expect(buildChatAgentSystemPrompt(baseOptions)).toContain(
+      'DOCUMENTATION:\n- When you are unsure',
+    )
+    const prompt = buildChatAgentSystemPrompt({
+      ...baseOptions,
+      disabledTools: ['search_docs', 'read_doc'],
+    })
+    expect(prompt).not.toContain('DOCUMENTATION:')
+    expect(prompt).not.toContain('search_docs')
+    expect(prompt).not.toContain('read_doc')
+  })
+
   it('leaves the prompt byte-identical for an empty list', () => {
     expect(buildChatAgentSystemPrompt({ ...baseOptions, disabledTools: [] })).toBe(
       buildChatAgentSystemPrompt(baseOptions),

--- a/lib/llm/chatAgentPrompt.ts
+++ b/lib/llm/chatAgentPrompt.ts
@@ -382,6 +382,17 @@ const ARTIFACT_MANAGEMENT_GUIDANCE: readonly ToolGuidance[] = [
   },
 ]
 
+const DOCUMENTATION_GUIDANCE: readonly ToolGuidance[] = [
+  {
+    tool: 'search_docs',
+    text: '- When you are unsure how to express something in Trilogy — window functions, date handling, filtering on aggregates, an unfamiliar keyword — call search_docs (kind: language or function) and then read_doc, rather than guessing at syntax. The reference above is a summary; the docs carry the full idioms.',
+  },
+  {
+    tool: 'read_doc',
+    text: '- read_doc returns the full article for an id from search_docs; quote the relevant part back to the user when they ask how the language works.',
+  },
+]
+
 /** Numbered on render, so dropping a step keeps the list contiguous. */
 const ARTIFACT_CURATION_STEPS: readonly ToolGuidance[] = [
   { tool: 'list_artifacts', text: 'Call list_artifacts to see everything currently in the panel.' },
@@ -426,6 +437,11 @@ export function buildChatAgentSystemPrompt(options: ChatAgentPromptOptions): str
   const artifactCurationSection = enabledGuidance(ARTIFACT_CURATION_STEPS, disabledTools)
     .map((line, index) => `${index + 1}. ${line.text}`)
     .join('\n')
+  const documentationLines = enabledGuidance(DOCUMENTATION_GUIDANCE, disabledTools)
+  const documentationSection =
+    documentationLines.length > 0
+      ? `\n\nDOCUMENTATION:\n${documentationLines.map((line) => line.text).join('\n')}`
+      : ''
 
   const conceptsSection =
     availableConcepts && availableConcepts.length > 0
@@ -472,7 +488,7 @@ IMPORTANT GUIDELINES:
 5. Use the full field path (e.g., 'order.product.id') - never use FROM clauses
 6. Remember: No GROUP BY clause - grouping is implicit by non-aggregated fields in SELECT
 7. If the user question needs fields that are not in the same source, use select_active_import to switch to a different data source (only one can be active at a time). Always consider this when they change topics.
-8. If the data connection is not active, use connect_data_connection to establish the connection before running queries
+8. If the data connection is not active, use connect_data_connection to establish the connection before running queries${documentationSection}
 
 ARTIFACT MANAGEMENT:
 ${artifactManagementSection}

--- a/lib/llm/chatAgentPrompt.ts
+++ b/lib/llm/chatAgentPrompt.ts
@@ -8,6 +8,8 @@ import {
 import { conceptsToFieldPrompt } from './data/prompts'
 import type { ModelConceptInput } from './data/models'
 import type { ChatImport } from '../chats/chat'
+import type { LLMToolDefinition } from './base'
+import type { ToolCallResult } from './sharedToolHelpers'
 import {
   chartConfigSchema,
   chartConfigGuidance,
@@ -342,6 +344,47 @@ export function filterDisabledTools<T extends { name: string }>(
   if (!disabledTools || disabledTools.length === 0) return tools
   const disabled = new Set(disabledTools)
   return tools.filter((tool) => !disabled.has(tool.name))
+}
+
+/**
+ * A tool the host application adds to a persistent chat: its definition for
+ * the model and the function that runs it. The natural sibling of
+ * `disabledTools`. The executor receives the model's input and returns a
+ * ToolCallResult; a throw is caught and reported to the model as an error.
+ */
+export interface HostChatTool {
+  definition: LLMToolDefinition
+  execute: (input: Record<string, any>) => Promise<ToolCallResult> | ToolCallResult
+}
+
+/**
+ * Append host tools to a toolset, keeping `return_to_user` last so the
+ * "always end with return_to_user" contract reads the same to the model.
+ * A host tool may not shadow a built-in: that is a programming error, not a
+ * runtime condition, so it throws. With no extra tools the input array is
+ * returned as-is, keeping the registry's identity contract.
+ */
+export function mergeExtraTools<T extends { name: string }>(
+  tools: T[],
+  extraTools: readonly HostChatTool[] | undefined,
+): T[] {
+  if (!extraTools || extraTools.length === 0) return tools
+  const builtin = new Set(tools.map((tool) => tool.name))
+  const seen = new Set<string>()
+  const extra = extraTools.map((tool) => {
+    const name = tool.definition.name
+    if (builtin.has(name)) {
+      throw new Error(`Host tool '${name}' shadows a built-in chat tool`)
+    }
+    if (seen.has(name)) {
+      throw new Error(`Host tool '${name}' is declared twice`)
+    }
+    seen.add(name)
+    return tool.definition as unknown as T
+  })
+  const returnIndex = tools.findIndex((tool) => tool.name === RETURN_TO_USER_TOOL.name)
+  if (returnIndex === -1) return [...tools, ...extra]
+  return [...tools.slice(0, returnIndex), ...extra, ...tools.slice(returnIndex)]
 }
 
 /** A line of prompt guidance, tagged with the tool it tells the model to use

--- a/lib/llm/chatAgentPrompt.ts
+++ b/lib/llm/chatAgentPrompt.ts
@@ -336,9 +336,9 @@ export interface ChatAgentPromptOptions {
  * the input array is returned as-is, keeping the registry's identity contract.
  */
 export function filterDisabledTools<T extends { name: string }>(
-  tools: readonly T[],
+  tools: T[],
   disabledTools: readonly string[] | undefined,
-): readonly T[] {
+): T[] {
   if (!disabledTools || disabledTools.length === 0) return tools
   const disabled = new Set(disabledTools)
   return tools.filter((tool) => !disabled.has(tool.name))

--- a/lib/llm/chatAgentPrompt.ts
+++ b/lib/llm/chatAgentPrompt.ts
@@ -320,6 +320,93 @@ export interface ChatAgentPromptOptions {
   activeImports?: ChatImport[] // Currently imported data sources
   availableImportsForConnection?: ChatImport[] // All available imports for current connection
   isDataConnectionActive?: boolean // Whether the current data connection is connected
+  /**
+   * Names of chat tools the host has withheld from this conversation (see
+   * `filterDisabledTools`). Guidance that tells the model to call one of them
+   * is dropped so the prompt never asks for a tool the toolset does not carry.
+   */
+  disabledTools?: readonly string[]
+}
+
+/**
+ * Remove withheld tools from a toolset. A host whose surface makes a tool
+ * meaningless — an artifact panel that is not there to reorder, say — drops it
+ * here rather than editing CHAT_TOOLS, so the shared registry's cached
+ * toolset stays intact for every other conversation. With nothing disabled
+ * the input array is returned as-is, keeping the registry's identity contract.
+ */
+export function filterDisabledTools<T extends { name: string }>(
+  tools: readonly T[],
+  disabledTools: readonly string[] | undefined,
+): readonly T[] {
+  if (!disabledTools || disabledTools.length === 0) return tools
+  const disabled = new Set(disabledTools)
+  return tools.filter((tool) => !disabled.has(tool.name))
+}
+
+/** A line of prompt guidance, tagged with the tool it tells the model to use
+ *  so it can be dropped alongside that tool. */
+interface ToolGuidance {
+  tool?: string
+  text: string
+}
+
+const ARTIFACT_MANAGEMENT_GUIDANCE: readonly ToolGuidance[] = [
+  {
+    text: '- Every query and chart tool call returns an artifact ID. Use these IDs to reference, update, or remove artifacts later.',
+  },
+  {
+    tool: 'create_markdown',
+    text: `- Use create_markdown to create rich formatted content: reports, summaries, annotated insights, data-driven narratives.
+  - Markdown supports template expressions when a query is provided: {field_name}, {data[0].field}, {{#each data limit=5}} {field} {{/each}}`,
+  },
+  {
+    tool: 'list_artifacts',
+    text: '- Use list_artifacts to see all artifacts with their IDs, types, and metadata.',
+  },
+  {
+    tool: 'get_artifact',
+    text: '- Use get_artifact to inspect the full contents and configuration of a specific artifact.',
+  },
+  {
+    tool: 'update_artifact',
+    text: '- Use update_artifact to modify existing artifacts (change markdown content, title, or chart configuration).',
+  },
+  {
+    tool: 'hide_artifact',
+    text: '- Use hide_artifact to remove stale or superseded artifacts from the main view. Hidden artifacts are preserved and accessible to both you and the user — they are not deleted.',
+  },
+  {
+    tool: 'create_markdown',
+    text: '- When the user asks for a summary, report, or narrative, prefer create_markdown over just text responses - it renders in the artifacts panel.',
+  },
+]
+
+/** Numbered on render, so dropping a step keeps the list contiguous. */
+const ARTIFACT_CURATION_STEPS: readonly ToolGuidance[] = [
+  { tool: 'list_artifacts', text: 'Call list_artifacts to see everything currently in the panel.' },
+  {
+    tool: 'hide_artifact',
+    text: 'Hide stale or superseded artifacts using hide_artifact — failed queries, test runs, intermediate steps, or results from earlier questions that are no longer relevant to the current ask. Hidden artifacts are preserved (the user can restore them) and you can still reference them by ID.',
+  },
+  {
+    tool: 'update_artifact',
+    text: 'Update titles: give each remaining artifact a clear, descriptive title that explains what it shows (via update_artifact).',
+  },
+  {
+    tool: 'reorder_artifacts',
+    text: 'Reorder artifacts for maximum impact — put the most important artifact first (e.g., a summary markdown or key chart), followed by supporting detail. The artifacts panel is the primary view the user sees.',
+  },
+  {
+    text: "The artifact panel should tell a coherent story that directly answers the user's latest request — not accumulate a growing pile from every prior turn.",
+  },
+]
+
+function enabledGuidance(
+  lines: readonly ToolGuidance[],
+  disabledTools: readonly string[],
+): ToolGuidance[] {
+  return lines.filter((line) => !line.tool || !disabledTools.includes(line.tool))
 }
 
 export function buildChatAgentSystemPrompt(options: ChatAgentPromptOptions): string {
@@ -330,7 +417,15 @@ export function buildChatAgentSystemPrompt(options: ChatAgentPromptOptions): str
     activeImports = [],
     availableImportsForConnection = [],
     isDataConnectionActive = true,
+    disabledTools = [],
   } = options
+
+  const artifactManagementSection = enabledGuidance(ARTIFACT_MANAGEMENT_GUIDANCE, disabledTools)
+    .map((line) => line.text)
+    .join('\n')
+  const artifactCurationSection = enabledGuidance(ARTIFACT_CURATION_STEPS, disabledTools)
+    .map((line, index) => `${index + 1}. ${line.text}`)
+    .join('\n')
 
   const conceptsSection =
     availableConcepts && availableConcepts.length > 0
@@ -380,22 +475,11 @@ IMPORTANT GUIDELINES:
 8. If the data connection is not active, use connect_data_connection to establish the connection before running queries
 
 ARTIFACT MANAGEMENT:
-- Every query and chart tool call returns an artifact ID. Use these IDs to reference, update, or remove artifacts later.
-- Use create_markdown to create rich formatted content: reports, summaries, annotated insights, data-driven narratives.
-  - Markdown supports template expressions when a query is provided: {field_name}, {data[0].field}, {{#each data limit=5}} {field} {{/each}}
-- Use list_artifacts to see all artifacts with their IDs, types, and metadata.
-- Use get_artifact to inspect the full contents and configuration of a specific artifact.
-- Use update_artifact to modify existing artifacts (change markdown content, title, or chart configuration).
-- Use hide_artifact to remove stale or superseded artifacts from the main view. Hidden artifacts are preserved and accessible to both you and the user — they are not deleted.
-- When the user asks for a summary, report, or narrative, prefer create_markdown over just text responses - it renders in the artifacts panel.
+${artifactManagementSection}
 
 ARTIFACT CURATION (required before every return_to_user call):
 Before calling return_to_user, you MUST curate the artifact panel so it reflects a clean, coherent answer to the user's current request:
-1. Call list_artifacts to see everything currently in the panel.
-2. Hide stale or superseded artifacts using hide_artifact — failed queries, test runs, intermediate steps, or results from earlier questions that are no longer relevant to the current ask. Hidden artifacts are preserved (the user can restore them) and you can still reference them by ID.
-3. Update titles: give each remaining artifact a clear, descriptive title that explains what it shows (via update_artifact).
-4. Reorder artifacts for maximum impact — put the most important artifact first (e.g., a summary markdown or key chart), followed by supporting detail. The artifacts panel is the primary view the user sees.
-5. The artifact panel should tell a coherent story that directly answers the user's latest request — not accumulate a growing pile from every prior turn.
+${artifactCurationSection}
 
 COMPLETING YOUR RESPONSE:
 - When you have finished addressing the user's request AND curated the artifact panel, call return_to_user with a brief summary.

--- a/lib/llm/registry/toolRegistry.test.ts
+++ b/lib/llm/registry/toolRegistry.test.ts
@@ -26,12 +26,23 @@ describe('ToolRegistry', () => {
     resetSharedRegistryForTests()
   })
 
-  it('golden: chat context toolset deep-equals the legacy CHAT_TOOLS array', () => {
+  it('golden: chat context toolset is CHAT_TOOLS plus the docs pack, return_to_user last', () => {
     // This is the release gate for "the tool union changed": any drift here
     // means the tool array sent to providers changed, which busts the
     // Anthropic prompt-cache prefix for every existing conversation.
     const registry = buildDefaultRegistry()
-    expect(registry.getToolsetForContext('chat')).toEqual([...CHAT_TOOLS])
+    const chatToolNames = CHAT_TOOLS.map((tool) => tool.name)
+    expect(registry.getToolNames('chat')).toEqual([
+      ...chatToolNames.filter((name) => name !== 'return_to_user'),
+      'search_docs',
+      'read_doc',
+      'open_documentation',
+      'return_to_user',
+    ])
+    // The legacy definitions keep their identity; only the docs pack is new.
+    for (const tool of CHAT_TOOLS) {
+      expect(registry.getToolsetForContext('chat')).toContain(tool)
+    }
   })
 
   it('returns the same array instance per context (memoized identity)', () => {

--- a/lib/llm/registry/toolRegistry.ts
+++ b/lib/llm/registry/toolRegistry.ts
@@ -8,7 +8,11 @@ import type { RegisteredTool, ToolPackId, ToolRuntime, ToolSession, ToolContext 
 export type ToolsetContextId = 'chat' | 'global' | 'editor-trilogy' | 'editor-sql' | 'dashboard'
 
 const TOOLSET_PACKS: Record<ToolsetContextId, ToolPackId[]> = {
-  chat: ['data', 'artifacts', 'base'],
+  // 'docs' gives the chat agent search_docs/read_doc so it can look up
+  // language idioms instead of guessing; open_documentation rides along but
+  // declares its own availability, so a host without app navigation gets a
+  // graceful hint (or withholds it via disabledTools).
+  chat: ['data', 'artifacts', 'docs', 'base'],
   // Placeholder compositions until their packs land; resolving a context only
   // uses packs that have registered tools, so these are safe to declare early.
   global: [

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trilogy-data/trilogy-studio-components",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/lib/stores/chatStore.execution.test.ts
+++ b/lib/stores/chatStore.execution.test.ts
@@ -82,6 +82,44 @@ describe('chatStore.executeMessage lifecycle', () => {
     await run
   })
 
+  it('extraTools reach the model and run the host executor when called', async () => {
+    const store = useChatStore()
+    const chat = store.newChat('llm-1')
+    const llm = makeDeferredLLM()
+    const deps = makeDeps(llm)
+    const execute = vi.fn().mockResolvedValue({ success: true, message: 'opened rockets view' })
+
+    const run = store.executeMessage(chat.id, 'show me on the globe', deps, {
+      extraTools: [
+        {
+          definition: {
+            name: 'show_in_view',
+            description: 'Open a visualisation',
+            input_schema: { type: 'object', properties: { view: { type: 'string' } } },
+          },
+          execute,
+        },
+      ],
+    })
+    await vi.waitFor(() => expect(llm.calls.length).toBe(1))
+
+    const names = llm.calls[0].options.tools.map((t: { name: string }) => t.name)
+    expect(names.at(-1)).toBe('return_to_user')
+    expect(names.at(-2)).toBe('show_in_view')
+
+    llm.calls[0].resolve({
+      text: '',
+      toolCalls: [{ id: 'call-1', name: 'show_in_view', input: { view: 'rockets' } }],
+    })
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledWith({ view: 'rockets' }))
+    // The loop feeds the result back and asks the model again.
+    await vi.waitFor(() => expect(llm.calls.length).toBe(2))
+
+    store.stopExecution(chat.id)
+    llm.calls[1].resolve({ text: 'done', toolCalls: [] })
+    await run
+  })
+
   it('the default path sends the full toolset when nothing is disabled', async () => {
     const store = useChatStore()
     const chat = store.newChat('llm-1')

--- a/lib/stores/chatStore.execution.test.ts
+++ b/lib/stores/chatStore.execution.test.ts
@@ -57,6 +57,49 @@ describe('chatStore.executeMessage lifecycle', () => {
     setActivePinia(createPinia())
   })
 
+  it('disabledTools withholds the tool and its guidance on the default path', async () => {
+    const store = useChatStore()
+    const chat = store.newChat('llm-1')
+    const llm = makeDeferredLLM()
+    const deps = makeDeps(llm)
+
+    const run = store.executeMessage(chat.id, 'show me launches', deps, {
+      disabledTools: ['reorder_artifacts'],
+    })
+    await vi.waitFor(() => expect(llm.calls.length).toBe(1))
+
+    const request = llm.calls[0].options
+    const toolNames = request.tools.map((t: { name: string }) => t.name)
+    expect(toolNames).toContain('list_artifacts')
+    expect(toolNames).not.toContain('reorder_artifacts')
+    expect(request.systemPrompt).not.toContain('reorder_artifacts')
+    expect(request.systemPrompt).not.toContain('Reorder artifacts')
+
+    // The default path keeps prompting until a tool is called; stop it here
+    // rather than driving the loop through the registry's real executors.
+    store.stopExecution(chat.id)
+    llm.calls[0].resolve({ text: 'done', toolCalls: [] })
+    await run
+  })
+
+  it('the default path sends the full toolset when nothing is disabled', async () => {
+    const store = useChatStore()
+    const chat = store.newChat('llm-1')
+    const llm = makeDeferredLLM()
+    const deps = makeDeps(llm)
+
+    const run = store.executeMessage(chat.id, 'show me launches', deps)
+    await vi.waitFor(() => expect(llm.calls.length).toBe(1))
+
+    const request = llm.calls[0].options
+    expect(request.tools.map((t: { name: string }) => t.name)).toContain('reorder_artifacts')
+    expect(request.systemPrompt).toContain('Reorder artifacts')
+
+    store.stopExecution(chat.id)
+    llm.calls[0].resolve({ text: 'done', toolCalls: [] })
+    await run
+  })
+
   it('a superseded run must not clobber the new run or leave error bubbles', async () => {
     const store = useChatStore()
     const chat = store.newChat('llm-1')

--- a/lib/stores/chatStore.ts
+++ b/lib/stores/chatStore.ts
@@ -12,7 +12,12 @@ import { OverseerToolExecutor } from '../llm/overseerToolExecutor'
 import { ArchitectToolExecutor } from '../llm/architectToolExecutor'
 import { summarizeSubchat } from '../llm/subchatSummarize'
 import type { ToolCallResult } from '../llm/sharedToolHelpers'
-import { buildChatAgentSystemPrompt, filterDisabledTools } from '../llm/chatAgentPrompt'
+import {
+  buildChatAgentSystemPrompt,
+  filterDisabledTools,
+  mergeExtraTools,
+  type HostChatTool,
+} from '../llm/chatAgentPrompt'
 import { getSharedRegistry } from '../llm/registry'
 import { maybeCompactChat } from '../llm/compaction'
 import {
@@ -424,6 +429,11 @@ export const useChatStore = defineStore('chats', {
          *  the toolset is part of the provider's prompt-cache prefix, so
          *  changing it mid-conversation costs one cache miss. */
         disabledTools?: readonly string[]
+        /** Host-defined tools added to this run (default path only). Their
+         *  definitions go to the model after the built-ins, ahead of
+         *  return_to_user, and calls to them run the host's executor instead
+         *  of the registry. Same prompt-cache caveat as disabledTools. */
+        extraTools?: readonly HostChatTool[]
       } = {},
     ): Promise<{ response?: string; artifacts?: ChatArtifact[] } | void> {
       const chat = this.chats[chatId]
@@ -593,7 +603,30 @@ export const useChatStore = defineStore('chats', {
                     },
                     { chatId, cache: new Map() },
                   )
-                  return { getToolExecutor: () => toolExecutor }
+                  const hostTools = new Map(
+                    (options.extraTools ?? []).map((tool) => [tool.definition.name, tool]),
+                  )
+                  if (hostTools.size === 0) {
+                    return { getToolExecutor: () => toolExecutor }
+                  }
+                  // Host tools take the call when the name is theirs; the
+                  // registry keeps everything else, including unknown names.
+                  const withHostTools = {
+                    executeToolCall: async (
+                      toolName: string,
+                      toolInput: Record<string, any>,
+                    ): Promise<ToolCallResult> => {
+                      const hostTool = hostTools.get(toolName)
+                      if (!hostTool) return toolExecutor.executeToolCall(toolName, toolInput)
+                      try {
+                        return await hostTool.execute(toolInput)
+                      } catch (err) {
+                        const message = err instanceof Error ? err.message : String(err)
+                        return { success: false, error: `Tool '${toolName}' failed: ${message}` }
+                      }
+                    },
+                  }
+                  return { getToolExecutor: () => withHostTools }
                 })()
 
         const stateUpdater: ExecutionStateUpdater = {
@@ -622,9 +655,12 @@ export const useChatStore = defineStore('chats', {
             ? OVERSEER_TOOLS
             : chat.kind === 'architect'
               ? ARCHITECT_TOOLS
-              : filterDisabledTools(
-                  getSharedRegistry().getToolsetForContext('chat'),
-                  options.disabledTools,
+              : mergeExtraTools(
+                  filterDisabledTools(
+                    getSharedRegistry().getToolsetForContext('chat'),
+                    options.disabledTools,
+                  ),
+                  options.extraTools,
                 )
 
         const loopResult = await runToolLoop(

--- a/lib/stores/chatStore.ts
+++ b/lib/stores/chatStore.ts
@@ -12,7 +12,7 @@ import { OverseerToolExecutor } from '../llm/overseerToolExecutor'
 import { ArchitectToolExecutor } from '../llm/architectToolExecutor'
 import { summarizeSubchat } from '../llm/subchatSummarize'
 import type { ToolCallResult } from '../llm/sharedToolHelpers'
-import { buildChatAgentSystemPrompt } from '../llm/chatAgentPrompt'
+import { buildChatAgentSystemPrompt, filterDisabledTools } from '../llm/chatAgentPrompt'
 import { getSharedRegistry } from '../llm/registry'
 import { maybeCompactChat } from '../llm/compaction'
 import {
@@ -418,6 +418,12 @@ export const useChatStore = defineStore('chats', {
          *  the UI as a user-typed message. Used for subchat-completion
          *  injections into the overseer. */
         hiddenUserMessage?: boolean
+        /** Chat tools to withhold from this run, by name (default path only;
+         *  `overrides` carry their own toolset). The matching prompt guidance
+         *  is dropped with them. Keep the list stable across a conversation:
+         *  the toolset is part of the provider's prompt-cache prefix, so
+         *  changing it mid-conversation costs one cache miss. */
+        disabledTools?: readonly string[]
       } = {},
     ): Promise<{ response?: string; artifacts?: ChatArtifact[] } | void> {
       const chat = this.chats[chatId]
@@ -599,7 +605,7 @@ export const useChatStore = defineStore('chats', {
         // Build system prompt function (called each iteration for freshness)
         const buildSystemPrompt = options.overrides
           ? options.overrides.buildSystemPrompt
-          : () => this.buildSystemPrompt(chatId, deps)
+          : () => this.buildSystemPrompt(chatId, deps, options.disabledTools)
 
         // Handle symbol refresh on tool results (default path only)
         const onToolResult = options.overrides
@@ -616,7 +622,10 @@ export const useChatStore = defineStore('chats', {
             ? OVERSEER_TOOLS
             : chat.kind === 'architect'
               ? ARCHITECT_TOOLS
-              : getSharedRegistry().getToolsetForContext('chat')
+              : filterDisabledTools(
+                  getSharedRegistry().getToolsetForContext('chat'),
+                  options.disabledTools,
+                )
 
         const loopResult = await runToolLoop(
           message,
@@ -760,7 +769,11 @@ export const useChatStore = defineStore('chats', {
     },
 
     /** Build the system prompt for a chat based on its current state */
-    buildSystemPrompt(chatId: string, deps: ChatExecutionDependencies): string {
+    buildSystemPrompt(
+      chatId: string,
+      deps: ChatExecutionDependencies,
+      disabledTools?: readonly string[],
+    ): string {
       const chat = this.chats[chatId]
       if (!chat) return ''
 
@@ -811,6 +824,7 @@ export const useChatStore = defineStore('chats', {
         activeImports: chat.imports,
         availableImportsForConnection: availableImports,
         isDataConnectionActive,
+        disabledTools,
       })
 
       // Analyst subchats still ride on the generic CHAT_TOOLS for now —

--- a/pyserver/mcp_server.py
+++ b/pyserver/mcp_server.py
@@ -3,6 +3,7 @@ from functools import wraps
 
 import httpx
 from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from trilogy import Dialects, Environment
 from trilogy.authoring import Concept
 from trilogy.core.models.core import (
@@ -303,7 +304,10 @@ def create_connection(name: str, model_name: str) -> str:
 def list_connection_fields(name: str) -> list[dict]:
     """List datasets in a connection"""
     if name not in CONNECTIONS:
-        raise ValueError(f"Connection '{name}' does not exist.")
+        # An anticipated failure the model should read and correct. mcp>=2.1
+        # masks anything but ToolError as a crash ("Error executing tool
+        # <name>"), so a ValueError here would hide the connection name.
+        raise ToolError(f"Connection '{name}' does not exist.")
     executor = CONNECTIONS[name]
     return [
         process_concept(c)

--- a/pyserver/tests/test_mcp_server.py
+++ b/pyserver/tests/test_mcp_server.py
@@ -93,8 +93,10 @@ class TestToolInvocation:
         assert "cleared" in result.structured_content["result"]
 
     def test_unknown_connection_surfaces_as_a_tool_error(self):
-        # The tool layer wraps a raised ValueError as ToolError rather than
-        # returning is_error=True; the protocol layer above converts it.
+        # The tool raises ToolError (an anticipated failure) rather than
+        # returning is_error=True; the protocol layer above converts it. The
+        # SDK prefixes the message with "Error executing tool <name>: " and
+        # keeps ours, whereas any other exception is masked to the prefix.
         with pytest.raises(ToolError, match="Connection 'nope' does not exist"):
             run(mcp.call_tool("list_connection_fields", {"name": "nope"}))
 


### PR DESCRIPTION
## Summary

Library changes surfaced while fixing the chat view in an embedding app (greenmtnboy/space_reporting#47), plus the version bump to publish them.

### Docs pack in the chat toolset
The chat agent could only guess at Trilogy idioms the prompt's syntax summary does not cover. The `chat` toolset context now includes the docs pack: `search_docs` and `read_doc` let it look up window functions, date handling, filtering on aggregates and the like from the in-app documentation, and a new DOCUMENTATION section in the system prompt tells it to do that rather than guess. `open_documentation` rides along; it already declares its own availability, so a host without app navigation gets a graceful hint or withholds it via `disabledTools`. The registry's golden test for the chat toolset is updated to the new composition (`return_to_user` still last). Note this changes the tool array for existing studio chat conversations once, busting their prompt-cache prefix on the next send.

### `disabledTools` on `useTrilogyChat` / `useChatWithTools`
A host surface can make a chat tool pointless — a narrow layout with artifacts inline has no panel for `reorder_artifacts` to reorder, yet the curation guidance still sent the model to reorder every turn. `disabledTools` (list, ref or getter of tool names) is threaded to `chatStore.executeMessage`, which filters the default toolset with `filterDisabledTools`, and to `buildChatAgentSystemPrompt`, which drops the artifact-management lines, curation steps and documentation lines that ask for a disabled tool and renumbers the steps. With nothing disabled, toolset and prompt are byte-identical to before, so the registry's cached-toolset identity contract holds.

### `extraTools` on `useTrilogyChat` / `useChatWithTools`
The counterpart: a host hands a persistent chat its own tools, each a definition for the model plus the function that runs it (`HostChatTool`). `mergeExtraTools` places the definitions after the built-ins and ahead of `return_to_user`; the store wraps the registry executor so a call to a host tool runs the host's function (a throw is reported to the model as a tool error) while every other name still goes to the registry. Shadowing a built-in name throws. `customTools` remains the standalone-mode equivalent.

### Icon masks no longer clobber a host's icon font
`registerMdiIcons` injected a bare `.mdi::before { content: ""; background-color: currentColor; ... }` rule. Because the sheet is appended to `<head>` at runtime it out-cascades any `@mdi/font` stylesheet a host page loads, so every `mdi-*` class the registry does not know rendered as a solid currentColor square. The mask box is now scoped to registered classes via `.mdi:is(.mdi-a, .mdi-b, …)::before`; unregistered icons fall through to whatever the host provides. Inside this repo (no font) an unregistered icon renders as nothing, which the existing registration test still guards.

### `DataTable` `showControls`
New prop (default `true`). Set `false` to drop the floating copy/download buttons; `copyToClipboard()` / `downloadData()` are documented as public so a host can drive the table from its own toolbar through a template ref.

### pyserver: `ToolError` for an unknown MCP connection
Not this PR's change originally, but it was red on CI: mcp 2.1 (released after the last green run) masks any exception but `ToolError` as a crash, so `test_unknown_connection_surfaces_as_a_tool_error` saw only `Error executing tool list_connection_fields`. A missing connection is an anticipated failure the model should read and correct, which is what `ToolError` is for. Reproduced locally on mcp 2.1.1; 25 pyserver MCP tests, mypy, ruff and black pass.

### Docs
`lib/README.md` gains sections on the chat documentation tools, adding host tools, withholding chat tools, and styling prerequisites: `DataTable` relies on Tabulator's base stylesheet, which the package does not ship and consumers must import (the studio app does; embedders were not told).

### Version
`lib/package.json` 0.1.23 → 0.1.24 (0.1.23 is already on npm).

## Tests
- `lib/llm/registry/toolRegistry.test.ts`: golden chat toolset is CHAT_TOOLS + docs pack, legacy definitions keep identity.
- `lib/llm/chatAgentPrompt.test.ts` (new): `filterDisabledTools` / `mergeExtraTools` identity contracts, ordering ahead of `return_to_user`, shadow/duplicate rejection; guidance dropped and renumbered per disabled tool; documentation section dropped when both docs tools are disabled; empty list is byte-identical.
- `lib/stores/chatStore.execution.test.ts`: default path withholds the tool and its guidance; host tool reaches the model and its executor runs on call; full toolset without the options.
- `lib/icons/registerMdiIcons.test.ts`: generated stylesheet never carries a bare `.mdi::before` mask rule; every registered icon gets a mask image.
- `lib/components/DataTable.test.ts` (new): controls render by default, are omitted with `showControls: false`, and the two actions are callable and safe before the table lays out.
- `vue-tsc --noEmit` clean at root and in `lib/`; `lib/llm`, `lib/stores`, `lib/composables`, `lib/components/llm` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsZuMFRBvYuwpiYuYQJqZN