### PR TITLE
[Infra] Run the resolver on a dedicated Fly core, scaled to zero when idle

### DIFF
--- a/pyserver/fly.toml
+++ b/pyserver/fly.toml
@@ -1,7 +1,20 @@
 # fly.toml app configuration file generated for trilogy-service on 2025-02-05T04:14:19-05:00
 #
-# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+# See https://fly.io/docs/reference/configuration/ for information about its
+# structure and available settings.
 #
+# CPU model (2026-09-04): dedicated cores, scaled to zero when idle.
+#
+# Every request is CPU-bound Python (parse + plan), and a dashboard fan-out is a
+# burst of them. On shared CPUs that burst spends the machine's burst quota and
+# the host then throttles it hard for a long time: Fly's own metrics on
+# 2026-09-04 showed ~92% CPU steal (184/200) for over an hour after one fan-out,
+# during which a 1 ms compile took seconds and every request hit the 120s
+# deadline. Steal on a performance VM is zero by construction. To keep the cost
+# in line with the old always-on shared machine, nothing runs while idle:
+# `min_machines_running = 0` lets the proxy stop every machine and start one on
+# the first request (boot + app import is a few seconds on a dedicated core;
+# the studio client already sends a warm-up request on load).
 
 app = 'trilogy-service'
 primary_region = 'ewr'
@@ -13,10 +26,22 @@ primary_region = 'ewr'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0
   processes = ['app']
+
+  # Count in-flight requests, not connections, so a fan-out on one machine
+  # wakes the second (soft_limit) before the app's own queue (see
+  # TRILOGY_MAX_QUEUED_REQUESTS in the Dockerfile) has to shed load.
+  [http_service.concurrency]
+    type = 'requests'
+    soft_limit = 8
+    hard_limit = 100
 
 [[vm]]
   memory = '2gb'
-  cpu_kind = 'shared'
-  cpus = 2
+  cpu_kind = 'performance'
+  # One dedicated core. performance-2x requires 4gb, and the workload is
+  # GIL-bound per process anyway; the Dockerfile's two gunicorn workers
+  # share this core, which costs nothing when idle and keeps one worker
+  # serving while the other recycles.
+  cpus = 1


### PR DESCRIPTION
## Why

Fly's own CPU metrics for `trilogy-service` on 2026-09-04 explain the "fan-out at 8 melts the instance and it stays slow for 40 minutes" reports: after one dashboard fan-out the `shared-cpu-2x` machine sat at ~92% CPU **steal** (184 of 200) for over an hour. The burst quota was spent and the host throttled the VM until a 1 ms compile took seconds and every request hit the 120 s deadline. That throttle predates #253 and no application change can recover CPU the host is withholding.

## What

`fly.toml` only, applied live with the already-deployed image (no rebuild):

- `cpu_kind = 'performance'`, `cpus = 1`, 2 GB. Dedicated core, zero steal. `performance-2x` was rejected (needs 4 GB) and each gunicorn worker is GIL-bound anyway.
- `min_machines_running = 0`: nothing runs while idle, so cost stays near the old always-on shared machine. Cold start is machine boot plus the app import; the studio client already sends a warm-up request on load.
- `[http_service.concurrency]` counts in-flight requests with `soft_limit = 8`, so a fan-out on one machine wakes the second before the app's own queue has to shed load. Observed in the logs during the test run.

## Measured on the live app after the change

Fan-out with `scripts/benchmark_concurrency.py`, TPC-H payload, 96 requests per level:

| concurrency | ok | timeouts | req p50 | req p95 | health p95 |
|---:|---:|---:|---:|---:|---:|
| 8 | 96/96 | 0 | 0.75 s | 2.4 s | 79 ms |
| 16 | 96/96 | 0 | 1.2 s | 3.3 s | 83 ms |
| 32 | 96/96 | 0 | 1.6 s | 5.1 s | 74 ms |

Zero `Timing out`, `Refusing`, or `WORKER TIMEOUT` lines in the log tail for the whole run. Under the same load on the shared machine earlier today, every request timed out at 120 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019koGAWxrKaQLf66KMZgkJP
